### PR TITLE
Make MigStorage fields optional 

### DIFF
--- a/config/crds/migration_v1alpha1_migstorage.yaml
+++ b/config/crds/migration_v1alpha1_migstorage.yaml
@@ -46,15 +46,6 @@ spec:
                   type: string
                 azureStorageAccount:
                   type: string
-              required:
-              - awsBucketName
-              - awsRegion
-              - awsS3ForcePathStyle
-              - awsPublicUrl
-              - awsKmsKeyId
-              - awsSignatureVersion
-              - azureStorageAccount
-              - azureResourceGroup
               type: object
             backupStorageProvider:
               type: string
@@ -66,10 +57,6 @@ spec:
                   type: string
                 azureResourceGroup:
                   type: string
-              required:
-              - awsRegion
-              - azureApiTimeout
-              - azureResourceGroup
               type: object
             volumeSnapshotProvider:
               type: string

--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -61,21 +61,21 @@ type MigStorageList struct {
 
 // VolumeSnapshotConfig defines config for taking Volume Snapshots
 type VolumeSnapshotConfig struct {
-	AwsRegion          string `json:"awsRegion"`
-	AzureAPITimeout    string `json:"azureApiTimeout"`
-	AzureResourceGroup string `json:"azureResourceGroup"`
+	AwsRegion          string `json:"awsRegion,omitempty"`
+	AzureAPITimeout    string `json:"azureApiTimeout,omitempty"`
+	AzureResourceGroup string `json:"azureResourceGroup,omitempty"`
 }
 
 // BackupStorageConfig defines config for creating and storing Backups
 type BackupStorageConfig struct {
-	AwsBucketName       string `json:"awsBucketName"`
-	AwsRegion           string `json:"awsRegion"`
-	AwsS3ForcePathStyle bool   `json:"awsS3ForcePathStyle"`
-	AwsPublicURL        string `json:"awsPublicUrl"`
-	AwsKmsKeyID         string `json:"awsKmsKeyId"`
-	AwsSignatureVersion string `json:"awsSignatureVersion"`
-	AzureStorageAccount string `json:"azureStorageAccount"`
-	AzureResourceGroup  string `json:"azureResourceGroup"`
+	AwsBucketName       string `json:"awsBucketName,omitempty"`
+	AwsRegion           string `json:"awsRegion,omitempty"`
+	AwsS3ForcePathStyle bool   `json:"awsS3ForcePathStyle,omitempty"`
+	AwsPublicURL        string `json:"awsPublicUrl,omitempty"`
+	AwsKmsKeyID         string `json:"awsKmsKeyId,omitempty"`
+	AwsSignatureVersion string `json:"awsSignatureVersion,omitempty"`
+	AzureStorageAccount string `json:"azureStorageAccount,omitempty"`
+	AzureResourceGroup  string `json:"azureResourceGroup,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
Make MigStorage fields optional  since users will never need to supply values for all options on the same MigStorage CR.

E.g. user would not supply AWS options and Azure options on the same MigStorage CR.