### PR TITLE
Validation additions and fixes.

### DIFF
--- a/pkg/apis/migration/v1alpha1/condition.go
+++ b/pkg/apis/migration/v1alpha1/condition.go
@@ -5,6 +5,17 @@ import (
 	"time"
 )
 
+// Types
+const (
+	Ready = "Ready"
+)
+
+// Status
+const (
+	True  = "True"
+	False = "False"
+)
+
 // Condition
 type Condition struct {
 	Type               string      `json:"type"`
@@ -77,4 +88,23 @@ func (r *Conditions) DeleteCondition(cndTypes ...string) {
 			r.Conditions = append(r.Conditions[:i], r.Conditions[i+1:]...)
 		}
 	}
+}
+
+// Set `Ready` condition.
+func (r *Conditions) SetReady(ready bool, message string) {
+	if ready {
+		r.SetCondition(Condition{
+			Type:    Ready,
+			Status:  True,
+			Message: message,
+		})
+	} else {
+		r.DeleteCondition(Ready)
+	}
+}
+
+// Get if `Ready` condition is `True`.
+func (r *Conditions) IsReady() bool {
+	_, condition := r.FindCondition(Ready)
+	return condition != nil && condition.Status == True
 }

--- a/pkg/controller/migassetcollection/migassetcollection_controller.go
+++ b/pkg/controller/migassetcollection/migassetcollection_controller.go
@@ -112,27 +112,15 @@ func (r *ReconcileMigAssetCollection) Reconcile(request reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	// Validations.
-	// The 'nSet' is the number of conditions set during validation.
-	err, nSet := r.validate(assetCollection)
+	// Validations
+	err, _ = r.validate(assetCollection)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	// Set the Ready condition
-	if nSet == 0 {
-		assetCollection.Status.SetCondition(migapi.Condition{
-			Type:    Ready,
-			Status:  True,
-			Message: ReadyMessage,
-		})
-	} else {
-		assetCollection.Status.DeleteCondition(Ready)
-	}
-	err = r.Update(context.TODO(), assetCollection)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
+	//
+	// ADD LOGIC HERE
+	//
 
 	// Done
 	return reconcile.Result{}, nil

--- a/pkg/controller/migassetcollection/validation.go
+++ b/pkg/controller/migassetcollection/validation.go
@@ -12,7 +12,6 @@ import (
 
 // Types
 const (
-	Ready              = "Ready"
 	EmptyCollection    = "EmptyCollection"
 	NamespacesNotFound = "NamespacesNotFound"
 )
@@ -24,8 +23,8 @@ const (
 
 // Statuses
 const (
-	True  = "True"
-	False = "False"
+	True  = migapi.True
+	False = migapi.False
 )
 
 // Messages
@@ -53,6 +52,9 @@ func (r ReconcileMigAssetCollection) validate(assetCollection *migapi.MigAssetCo
 		return err, 0
 	}
 	totalSet += nSet
+
+	// Ready
+	assetCollection.Status.SetReady(totalSet == 0, ReadyMessage)
 
 	// Apply changes
 	err = r.Update(context.TODO(), assetCollection)

--- a/pkg/controller/migcluster/validation.go
+++ b/pkg/controller/migcluster/validation.go
@@ -3,38 +3,208 @@ package migcluster
 import (
 	"context"
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
+	migref "github.com/fusor/mig-controller/pkg/reference"
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	crapi "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
 )
 
 // Types
 const (
-	Ready = "Ready"
+	InvalidClusterRef  = "InvalidClusterRef"
+	InvalidSaSecretRef = "InvalidSaSecretRef"
+	InvalidSaToken     = "InvalidSaToken"
 )
 
 // Reasons
-const ()
+const (
+	NotSet   = "NotSet"
+	NotFound = "NotFound"
+)
 
 // Statuses
 const (
-	True  = "True"
-	False = "False"
+	True  = migapi.True
+	False = migapi.False
 )
 
 // Messages
 const (
-	ReadyMessage = "The cluster is ready."
+	ReadyMessage              = "The cluster is ready."
+	InvalidClusterRefMessage  = "The `clusterRef` must reference a `cluster`."
+	InvalidSaSecretRefMessage = "The `serviceAccountSecretRef` must reference a `secret`."
+	InvalidSaTokenMessage     = "The `saToken` not found in `serviceAccountSecretRef` secret."
 )
 
 // Validate the asset collection resource.
 // Returns error and the total error conditions set.
-func (r ReconcileMigCluster) validate(assetCollection *migapi.MigCluster) (error, int) {
+func (r ReconcileMigCluster) validate(cluster *migapi.MigCluster) (error, int) {
 	totalSet := 0
 	var err error
+	nSet := 0
 
-	// Apply changes
-	err = r.Update(context.TODO(), assetCollection)
+	// registry cluster
+	err, nSet = r.validateRegistryCluster(cluster)
+	if err != nil {
+		return err, 0
+	}
+	totalSet += nSet
+
+	// SA secret
+	err, nSet = r.validateSaSecret(cluster)
+	if err != nil {
+		return err, 0
+	}
+	totalSet += nSet
+
+	// Ready
+	cluster.Status.SetReady(totalSet == 0, ReadyMessage)
+
+	// Apply changes.
+	err = r.Update(context.TODO(), cluster)
 	if err != nil {
 		return err, 0
 	}
 
 	return err, totalSet
+}
+
+func (r ReconcileMigCluster) validateRegistryCluster(cluster *migapi.MigCluster) (error, int) {
+	ref := cluster.Spec.ClusterRef
+
+	// NotSet
+	if !migref.RefSet(ref) {
+		cluster.Status.SetCondition(migapi.Condition{
+			Type:    InvalidClusterRef,
+			Status:  True,
+			Reason:  NotSet,
+			Message: InvalidClusterRefMessage,
+		})
+		return nil, 1
+	}
+
+	err, storage := r.getCluster(ref)
+	if err != nil {
+		return err, 0
+	}
+
+	// NotFound
+	if storage == nil {
+		cluster.Status.SetCondition(migapi.Condition{
+			Type:    InvalidClusterRef,
+			Status:  True,
+			Reason:  NotFound,
+			Message: InvalidClusterRefMessage,
+		})
+		return nil, 1
+	} else {
+		cluster.Status.DeleteCondition(InvalidClusterRef)
+	}
+
+	return nil, 0
+}
+
+func (r ReconcileMigCluster) getCluster(ref *kapi.ObjectReference) (error, *crapi.Cluster) {
+	key := types.NamespacedName{
+		Namespace: ref.Namespace,
+		Name:      ref.Name,
+	}
+
+	cluster := crapi.Cluster{}
+	err := r.Get(context.TODO(), key, &cluster)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		} else {
+			return err, nil
+		}
+	}
+
+	return nil, &cluster
+}
+
+func (r ReconcileMigCluster) validateSaSecret(cluster *migapi.MigCluster) (error, int) {
+	ref := cluster.Spec.ServiceAccountSecretRef
+
+	if cluster.Spec.IsHostCluster {
+		cluster.Status.DeleteCondition(InvalidSaSecretRef)
+		cluster.Status.DeleteCondition(InvalidSaToken)
+		return nil, 0
+	}
+
+	// NotSet
+	if !migref.RefSet(ref) {
+		cluster.Status.SetCondition(migapi.Condition{
+			Type:    InvalidSaSecretRef,
+			Status:  True,
+			Reason:  NotSet,
+			Message: InvalidSaSecretRefMessage,
+		})
+		cluster.Status.DeleteCondition(InvalidSaToken)
+		return nil, 1
+	}
+
+	err, secret := r.getSecret(ref)
+	if err != nil {
+		return err, 0
+	}
+
+	// NotFound
+	if secret == nil {
+		cluster.Status.SetCondition(migapi.Condition{
+			Type:    InvalidSaSecretRef,
+			Status:  True,
+			Reason:  NotFound,
+			Message: InvalidSaSecretRefMessage,
+		})
+		cluster.Status.DeleteCondition(InvalidSaToken)
+		return nil, 1
+	} else {
+		cluster.Status.DeleteCondition(InvalidSaSecretRef)
+	}
+
+	// saToken
+	token, found := secret.Data["saToken"]
+	if !found {
+		cluster.Status.SetCondition(migapi.Condition{
+			Type:    InvalidSaToken,
+			Status:  True,
+			Reason:  NotFound,
+			Message: InvalidSaTokenMessage,
+		})
+		return nil, 1
+	}
+	if len(token) == 0 {
+		cluster.Status.SetCondition(migapi.Condition{
+			Type:    InvalidSaToken,
+			Status:  True,
+			Reason:  NotSet,
+			Message: InvalidSaTokenMessage,
+		})
+		return nil, 1
+	} else {
+		cluster.Status.DeleteCondition(InvalidSaToken)
+	}
+
+	return nil, 0
+}
+
+func (r ReconcileMigCluster) getSecret(ref *kapi.ObjectReference) (error, *kapi.Secret) {
+	key := types.NamespacedName{
+		Namespace: ref.Namespace,
+		Name:      ref.Name,
+	}
+
+	secret := kapi.Secret{}
+	err := r.Get(context.TODO(), key, &secret)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		} else {
+			return err, nil
+		}
+	}
+
+	return nil, &secret
 }

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -133,26 +133,14 @@ func (r *ReconcileMigPlan) Reconcile(request reconcile.Request) (reconcile.Resul
 	}
 
 	// Validations.
-	// The 'nSet' is the number of conditions set during validation.
-	err, nSet := r.validate(plan)
+	err, _ = r.validate(plan)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	// Set the Ready condition
-	if nSet == 0 {
-		plan.Status.SetCondition(migapi.Condition{
-			Type:    Ready,
-			Status:  True,
-			Message: ReadyMessage,
-		})
-	} else {
-		plan.Status.DeleteCondition(Ready)
-	}
-	err = r.Update(context.TODO(), plan)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
+	//
+	// ADD LOGIC HERE
+	//
 
 	// Done
 	return reconcile.Result{}, nil

--- a/pkg/controller/migstorage/migstorage_controller.go
+++ b/pkg/controller/migstorage/migstorage_controller.go
@@ -96,26 +96,14 @@ func (r *ReconcileMigStorage) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Validations.
-	// The 'nSet' is the number of conditions set during validation.
-	err, nSet := r.validate(storage)
+	err, _ = r.validate(storage)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	// Set the Ready condition
-	if nSet == 0 {
-		storage.Status.SetCondition(migapi.Condition{
-			Type:    Ready,
-			Status:  True,
-			Message: ReadyMessage,
-		})
-	} else {
-		storage.Status.DeleteCondition(Ready)
-	}
-	err = r.Update(context.TODO(), storage)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
+	//
+	// ADD LOGIC HERE
+	//
 
 	// Done
 	return reconcile.Result{}, nil

--- a/pkg/reference/map.go
+++ b/pkg/reference/map.go
@@ -57,11 +57,15 @@ func (r *RefMap) Delete(refOwner RefOwner, refTarget RefTarget) {
 	if !found {
 		return
 	}
+	newList := []RefOwner{}
 	for i := range list {
 		if list[i] == refOwner {
-			list = append(list[:i], list[i+1:]...)
-			r.Content[refTarget] = list
+			continue
 		}
+		newList = append(newList, list[i])
+	}
+	if len(newList) < len(list) {
+		r.Content[refTarget] = newList
 	}
 }
 


### PR DESCRIPTION
Add new validations.
Fixes index out-of-bounds SEGV in `refmap.Delete()`.
Standardized management of `Ready` condition.  Add `Conditions.SetReady()` to better support validations & `Conditions.IsReady()` to support controllers.

Moves the determination of `Ready` from the `Reconcile()` to the `validate()`.  After working with this for a bit it seems more appropriate and prevents cases where the `Reconcile()` returns without validating.  Also, I could not think of anything other than _validation_ that would factor into determining when the resource is `Ready`.