### PR TITLE
Break out reconcile functions for MigMigration

### DIFF
--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -42,11 +42,6 @@ const logPrefix = "mMigration"
 // TODO: don't hard-code veleroNs
 const veleroNs = "velero"
 
-/**
-* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
-* business logic.  Delete these comments after modifying this file.*
- */
-
 // Add creates a new MigMigration Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -145,7 +140,7 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, err
 	}
 
-	// Ensure source cluster has a Velero Backup
+	// Ensure destination cluster has a Velero Backup + Restore
 	completed, err = r.ensureDestinationClusterRestore(migMigration)
 	if !completed {
 		return reconcile.Result{}, err

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -122,7 +122,7 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 	var rres *reconcileResources
 
 	// Perform prechecks and gather resources needed for reconcile
-	rres, err = r.initReconcile(migMigration)
+	rres, err = r.initMigration(migMigration)
 	if rres == nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -22,13 +22,9 @@ import (
 
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
-	vrunner "github.com/fusor/mig-controller/pkg/velerorunner"
 
-	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
-	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -42,6 +38,9 @@ import (
 var log = logf.Log.WithName("controller")
 
 const logPrefix = "mMigration"
+
+// TODO: don't hard-code veleroNs
+const veleroNs = "velero"
 
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
@@ -97,7 +96,8 @@ var _ reconcile.Reconciler = &ReconcileMigMigration{}
 // ReconcileMigMigration reconciles a MigMigration object
 type ReconcileMigMigration struct {
 	client.Client
-	scheme *runtime.Scheme
+	scheme    *runtime.Scheme
+	resources *reconcileResources
 }
 
 // Reconcile performs Migrations based on the data in MigMigration
@@ -107,10 +107,7 @@ type ReconcileMigMigration struct {
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migmigrations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migmigrations/status,verbs=get;update;patch
 func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.Info(fmt.Sprintf("[mMigration] RECONCILE [%s/%s]", request.Namespace, request.Name))
-
-	// Hardcode Velero namespace for now
-	veleroNs := "velero"
+	log.Info(fmt.Sprintf("[%s] RECONCILE [%s/%s]", logPrefix, request.Namespace, request.Name))
 
 	// Retrieve the MigMigration being reconciled
 	migMigration := &migapi.MigMigration{}
@@ -127,125 +124,37 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 	if err != nil {
 		return reconcile.Result{}, err // requeue
 	}
-	// Return if MigMigration is complete
-	if migMigration.Status.MigrationCompleted == true {
-		return reconcile.Result{}, nil // don't requeue
-	}
-	// Return if MigMigration isn't ready
-	if !migMigration.Status.IsReady() {
-		return reconcile.Result{}, nil //don't requeue
+
+	var completed bool
+
+	// Perform prechecks and gather resources needed for reconcile
+	completed, err = r.initReconcile(migMigration)
+	if !completed {
+		return reconcile.Result{}, err
 	}
 
-	// Build ReconcileResources for MigMigration containing data needed for rest of reconcile process
-	rres, err := r.getReconcileResources(migMigration)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return reconcile.Result{}, nil // don't requeue
-		}
-		return reconcile.Result{}, err // requeue
+	// Mark the MigMigration as started once prechecks are passed
+	completed, err = r.startMigMigration(migMigration)
+	if !completed {
+		return reconcile.Result{}, err
 	}
 
-	// If all references are marked as ready, run MarkAsRunning() to set this Migration into "Running" state
-	changed := migMigration.MarkAsRunning()
-	if changed {
-		err = r.Update(context.TODO(), migMigration)
-		if err != nil {
-			log.Info("[mMigration] Failed to mark MigMigration [%s/%s] as running", migMigration.Namespace, migMigration.Name)
-			return reconcile.Result{}, err // requeue
-		}
-		log.Info(fmt.Sprintf("[mMigration] STARTED MigMigration [%s/%s]", migMigration.Namespace, migMigration.Name))
-	}
-	// ******************************
-	// Build controller-runtime client for srcMigCluster
-	srcClusterK8sClient, err := rres.srcMigCluster.BuildControllerRuntimeClient(r.Client)
-	if err != nil {
-		log.Error(err, "Failed to GET srcClusterK8sClient")
-		return reconcile.Result{}, nil // don't requeue
+	// Ensure source cluster has a Velero Backup
+	completed, err = r.ensureSourceClusterBackup(migMigration)
+	if !completed {
+		return reconcile.Result{}, err
 	}
 
-	// Create Velero Backup on srcCluster looking at namespaces in MigAssetCollection
-	var backupNsName types.NamespacedName
-	if migMigration.Status.SrcBackupRef == nil {
-		backupNsName = types.NamespacedName{
-			Name:      migMigration.Name + "-",
-			Namespace: veleroNs,
-		}
-	} else {
-		backupNsName = types.NamespacedName{
-			Name:      migMigration.Status.SrcBackupRef.Name,
-			Namespace: migMigration.Status.SrcBackupRef.Namespace,
-		}
-	}
-	srcBackup, err := vrunner.RunBackup(srcClusterK8sClient, backupNsName, rres.migAssets, logPrefix)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return reconcile.Result{}, nil // don't requeue
-		}
-		return reconcile.Result{}, err // requeue
-	}
-	if srcBackup == nil {
-		return reconcile.Result{}, nil // don't requeue
-	}
-
-	// Update MigMigration with reference to Velero Backup
-	migMigration.Status.SrcBackupRef = &kapi.ObjectReference{Name: srcBackup.Name, Namespace: srcBackup.Namespace}
-	err = r.Update(context.TODO(), migMigration)
-	if err != nil {
-		log.Info(fmt.Sprintf("[mMigration] Failed to UPDATE MigMigration with Velero Backup reference"))
-		return reconcile.Result{}, err // requeue
-	}
-
-	// ******************************
-	// Build controller-runtime client for destMigCluster
-	destClusterK8sClient, err := rres.destMigCluster.BuildControllerRuntimeClient(r.Client)
-	if err != nil {
-		log.Error(err, "[mMigration] Failed to GET destClusterK8sClient")
-		return reconcile.Result{}, nil // don't requeue
-	}
-
-	// Create Velero Restore on destMigCluster pointing at Velero Backup unique name
-	var restoreNsName types.NamespacedName
-	if migMigration.Status.DestRestoreRef == nil {
-		restoreNsName = types.NamespacedName{
-			Name:      migMigration.Name + "-",
-			Namespace: veleroNs,
-		}
-	} else {
-		restoreNsName = types.NamespacedName{
-			Name:      migMigration.Status.DestRestoreRef.Name,
-			Namespace: migMigration.Status.DestRestoreRef.Namespace,
-		}
-	}
-	destRestore, err := vrunner.RunRestore(destClusterK8sClient, restoreNsName, backupNsName, logPrefix)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return reconcile.Result{}, nil // don't requeue
-		}
-		return reconcile.Result{}, err // requeue
-	}
-	if destRestore == nil {
-		return reconcile.Result{}, nil // don't requeue
-	}
-
-	// Update MigMigration with reference to Velero Retore
-	migMigration.Status.DestRestoreRef = &kapi.ObjectReference{Name: destRestore.Name, Namespace: destRestore.Namespace}
-	err = r.Update(context.TODO(), migMigration)
-	if err != nil {
-		log.Info(fmt.Sprintf("[mMigration] Failed to UPDATE MigMigration with Velero Restore reference"))
-		return reconcile.Result{}, err // requeue
+	// Ensure source cluster has a Velero Backup
+	completed, err = r.ensureDestinationClusterRestore(migMigration)
+	if !completed {
+		return reconcile.Result{}, err
 	}
 
 	// Mark MigMigration as complete if Velero Restore has completed
-	if destRestore.Status.Phase == velerov1.RestorePhaseCompleted {
-		changed = migMigration.MarkAsCompleted()
-		if changed {
-			err = r.Update(context.TODO(), migMigration)
-			if err != nil {
-				log.Info("[mMigration] Failed to mark MigMigration [%s/%s] as completed", migMigration.Namespace, migMigration.Name)
-				return reconcile.Result{}, err // requeue
-			}
-			log.Info(fmt.Sprintf("[mMigration] FINISHED MigMigration [%s/%s]", migMigration.Namespace, migMigration.Name))
-		}
+	completed, err = r.finishMigMigration(migMigration)
+	if !completed {
+		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func (r *ReconcileMigMigration) initReconcile(migMigration *migapi.MigMigration) (*reconcileResources, error) {
+func (r *ReconcileMigMigration) initMigration(migMigration *migapi.MigMigration) (*reconcileResources, error) {
 	// Return if MigMigration is complete
 	if migMigration.Status.MigrationCompleted == true {
 		return nil, nil // don't requeue

--- a/pkg/controller/migmigration/reconcile_core.go
+++ b/pkg/controller/migmigration/reconcile_core.go
@@ -68,7 +68,7 @@ func (r *ReconcileMigMigration) ensureSourceClusterBackup(migMigration *migapi.M
 	// Build controller-runtime client for srcMigCluster
 	srcClusterK8sClient, err := r.resources.srcMigCluster.BuildControllerRuntimeClient(r.Client)
 	if err != nil {
-		log.Error(err, "Failed to GET srcClusterK8sClient")
+		log.Error(err, "[%s] Failed to GET srcClusterK8sClient", logPrefix)
 		return false, nil // don't requeue
 	}
 
@@ -160,7 +160,6 @@ func (r *ReconcileMigMigration) ensureDestinationClusterRestore(migMigration *mi
 }
 
 func (r *ReconcileMigMigration) finishMigMigration(migMigration *migapi.MigMigration) (bool, error) {
-
 	if r.resources.destRestore.Status.Phase == velerov1.RestorePhaseCompleted {
 		changed := migMigration.MarkAsCompleted()
 		if changed {

--- a/pkg/controller/migmigration/reconcile_core.go
+++ b/pkg/controller/migmigration/reconcile_core.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2019 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migmigration
+
+import (
+	"context"
+	"fmt"
+
+	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
+	vrunner "github.com/fusor/mig-controller/pkg/velerorunner"
+	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func (r *ReconcileMigMigration) initReconcile(migMigration *migapi.MigMigration) (bool, error) {
+	// Return if MigMigration is complete
+	if migMigration.Status.MigrationCompleted == true {
+		return false, nil // don't requeue
+	}
+	// Return if MigMigration isn't ready
+	if !migMigration.Status.IsReady() {
+		return false, nil //don't requeue
+	}
+	// Build ReconcileResources for MigMigration containing data needed for rest of reconcile process
+	rres, err := r.getReconcileResources(migMigration)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil // don't requeue
+		}
+		return false, err // requeue
+	}
+
+	r.resources = rres
+	return true, nil
+}
+
+func (r *ReconcileMigMigration) startMigMigration(migMigration *migapi.MigMigration) (bool, error) {
+	// If all references are marked as ready, run MarkAsRunning() to set this Migration into "Running" state
+	changed := migMigration.MarkAsRunning()
+	if changed {
+		err := r.Update(context.TODO(), migMigration)
+		if err != nil {
+			log.Info("[%s] Failed to mark MigMigration [%s/%s] as running", logPrefix, migMigration.Namespace, migMigration.Name)
+			return false, err // requeue
+		}
+		log.Info(fmt.Sprintf("[%s] STARTED MigMigration [%s/%s]", logPrefix, migMigration.Namespace, migMigration.Name))
+	}
+	return true, nil
+}
+
+func (r *ReconcileMigMigration) ensureSourceClusterBackup(migMigration *migapi.MigMigration) (bool, error) {
+	// Build controller-runtime client for srcMigCluster
+	srcClusterK8sClient, err := r.resources.srcMigCluster.BuildControllerRuntimeClient(r.Client)
+	if err != nil {
+		log.Error(err, "Failed to GET srcClusterK8sClient")
+		return false, nil // don't requeue
+	}
+
+	// Create Velero Backup on srcCluster looking at namespaces in MigAssetCollection
+	var backupNsName types.NamespacedName
+	if migMigration.Status.SrcBackupRef == nil {
+		backupNsName = types.NamespacedName{
+			Name:      migMigration.Name + "-",
+			Namespace: veleroNs,
+		}
+	} else {
+		backupNsName = types.NamespacedName{
+			Name:      migMigration.Status.SrcBackupRef.Name,
+			Namespace: migMigration.Status.SrcBackupRef.Namespace,
+		}
+	}
+	srcBackup, err := vrunner.RunBackup(srcClusterK8sClient, backupNsName, r.resources.migAssets, logPrefix)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil // don't requeue
+		}
+		return false, err // requeue
+	}
+	if srcBackup == nil {
+		return false, nil // don't requeue
+	}
+	r.resources.srcBackup = srcBackup
+
+	// Update MigMigration with reference to Velero Backup
+	migMigration.Status.SrcBackupRef = &kapi.ObjectReference{Name: srcBackup.Name, Namespace: srcBackup.Namespace}
+	err = r.Update(context.TODO(), migMigration)
+	if err != nil {
+		log.Info(fmt.Sprintf("[%s] Failed to UPDATE MigMigration with Velero Backup reference", logPrefix))
+		return false, err // requeue
+	}
+
+	return true, nil
+}
+
+func (r *ReconcileMigMigration) ensureDestinationClusterRestore(migMigration *migapi.MigMigration) (bool, error) {
+	// Build controller-runtime client for destMigCluster
+	destClusterK8sClient, err := r.resources.destMigCluster.BuildControllerRuntimeClient(r.Client)
+	if err != nil {
+		log.Error(err, "[%s] Failed to GET destClusterK8sClient", logPrefix)
+		return false, nil // don't requeue
+	}
+
+	// Create Velero Restore on destMigCluster pointing at Velero Backup unique name
+	var restoreNsName types.NamespacedName
+	if migMigration.Status.DestRestoreRef == nil {
+		restoreNsName = types.NamespacedName{
+			Name:      migMigration.Name + "-",
+			Namespace: veleroNs,
+		}
+	} else {
+		restoreNsName = types.NamespacedName{
+			Name:      migMigration.Status.DestRestoreRef.Name,
+			Namespace: migMigration.Status.DestRestoreRef.Namespace,
+		}
+	}
+
+	// Reference the Velero Backup attached to the MigMigration
+	backupNsName := types.NamespacedName{
+		Name:      migMigration.Status.SrcBackupRef.Name,
+		Namespace: migMigration.Status.SrcBackupRef.Namespace,
+	}
+
+	destRestore, err := vrunner.RunRestore(destClusterK8sClient, restoreNsName, backupNsName, logPrefix)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil // don't requeue
+		}
+		return false, err // requeue
+	}
+	if destRestore == nil {
+		return false, nil // don't requeue
+	}
+	r.resources.destRestore = destRestore
+
+	// Update MigMigration with reference to Velero Retore
+	migMigration.Status.DestRestoreRef = &kapi.ObjectReference{Name: destRestore.Name, Namespace: destRestore.Namespace}
+	err = r.Update(context.TODO(), migMigration)
+	if err != nil {
+		log.Info(fmt.Sprintf("[%s] Failed to UPDATE MigMigration with Velero Restore reference", logPrefix))
+		return false, err // requeue
+	}
+
+	return true, nil
+}
+
+func (r *ReconcileMigMigration) finishMigMigration(migMigration *migapi.MigMigration) (bool, error) {
+
+	if r.resources.destRestore.Status.Phase == velerov1.RestorePhaseCompleted {
+		changed := migMigration.MarkAsCompleted()
+		if changed {
+			err := r.Update(context.TODO(), migMigration)
+			if err != nil {
+				log.Info("[%s] Failed to mark MigMigration [%s/%s] as completed", logPrefix, migMigration.Namespace, migMigration.Name)
+				return false, err // requeue
+			}
+			log.Info(fmt.Sprintf("[%s] FINISHED MigMigration [%s/%s]", logPrefix, migMigration.Namespace, migMigration.Name))
+		}
+	}
+	return true, nil
+}

--- a/pkg/controller/migmigration/reconcile_core.go
+++ b/pkg/controller/migmigration/reconcile_core.go
@@ -47,7 +47,7 @@ func (r *ReconcileMigMigration) initReconcile(migMigration *migapi.MigMigration)
 	}
 
 	r.resources = rres
-	return true, nil
+	return true, nil // continue
 }
 
 func (r *ReconcileMigMigration) startMigMigration(migMigration *migapi.MigMigration) (bool, error) {
@@ -61,7 +61,7 @@ func (r *ReconcileMigMigration) startMigMigration(migMigration *migapi.MigMigrat
 		}
 		log.Info(fmt.Sprintf("[%s] STARTED MigMigration [%s/%s]", logPrefix, migMigration.Namespace, migMigration.Name))
 	}
-	return true, nil
+	return true, nil // continue
 }
 
 func (r *ReconcileMigMigration) ensureSourceClusterBackup(migMigration *migapi.MigMigration) (bool, error) {
@@ -105,7 +105,7 @@ func (r *ReconcileMigMigration) ensureSourceClusterBackup(migMigration *migapi.M
 		return false, err // requeue
 	}
 
-	return true, nil
+	return true, nil // continue
 }
 
 func (r *ReconcileMigMigration) ensureDestinationClusterRestore(migMigration *migapi.MigMigration) (bool, error) {
@@ -156,7 +156,7 @@ func (r *ReconcileMigMigration) ensureDestinationClusterRestore(migMigration *mi
 		return false, err // requeue
 	}
 
-	return true, nil
+	return true, nil // continue
 }
 
 func (r *ReconcileMigMigration) finishMigMigration(migMigration *migapi.MigMigration) (bool, error) {
@@ -172,5 +172,5 @@ func (r *ReconcileMigMigration) finishMigMigration(migMigration *migapi.MigMigra
 			log.Info(fmt.Sprintf("[%s] FINISHED MigMigration [%s/%s]", logPrefix, migMigration.Namespace, migMigration.Name))
 		}
 	}
-	return true, nil
+	return true, nil // continue
 }

--- a/pkg/velerorunner/backup.go
+++ b/pkg/velerorunner/backup.go
@@ -49,10 +49,12 @@ func RunBackup(c client.Client, backupNsName types.NamespacedName, assets *migap
 			// Backup not found, 'Create'
 			err = c.Create(context.TODO(), vBackupNew)
 			if err != nil {
-				log.Info(fmt.Sprintf("[%s] Failed to CREATE Velero Backup on source cluster", logPrefix))
+				log.Info(fmt.Sprintf("[%s] Failed to CREATE Velero Backup [%s/%s] on source cluster",
+					logPrefix, vBackupNew.Namespace, vBackupNew.Name))
 				return nil, err
 			}
-			log.Info(fmt.Sprintf("[%s] Velero Backup CREATED successfully on source cluster", logPrefix))
+			log.Info(fmt.Sprintf("[%s] Velero Backup [%s/%s] CREATED successfully on source cluster",
+				logPrefix, vBackupNew.Namespace, vBackupNew.Name))
 			return vBackupNew, nil
 		}
 		return nil, err
@@ -63,12 +65,15 @@ func RunBackup(c client.Client, backupNsName types.NamespacedName, assets *migap
 		vBackupExisting.Spec = vBackupNew.Spec
 		err = c.Update(context.TODO(), vBackupExisting)
 		if err != nil {
-			log.Error(err, fmt.Sprintf("[%s] Failed to UPDATE Velero Backup on src cluster", logPrefix))
+			log.Error(err, fmt.Sprintf("[%s] Failed to UPDATE Velero Backup [%s/%s] on src cluster",
+				logPrefix, vBackupExisting.Namespace, vBackupExisting.Name))
 			return nil, err
 		}
-		log.Info(fmt.Sprintf("[%s] Velero Backup UPDATED successfully on source cluster", logPrefix))
+		log.Info(fmt.Sprintf("[%s] Velero Backup [%s/%s] UPDATED successfully on source cluster",
+			logPrefix, vBackupExisting.Namespace, vBackupExisting.Name))
 		return vBackupExisting, nil
 	}
-	log.Info(fmt.Sprintf("[%s] Velero Backup EXISTS on source cluster", logPrefix))
+	log.Info(fmt.Sprintf("[%s] Velero Backup [%s/%s] EXISTS on source cluster",
+		logPrefix, vBackupExisting.Namespace, vBackupExisting.Name))
 	return vBackupExisting, nil
 }


### PR DESCRIPTION
 - Reduce migmigration_controller.go reconcile to a sequence of simple calls

```
// Validate MigMigration contents
r.validate(migMigration)

// Perform prechecks and gather resources needed for reconcile
r.initReconcile(migMigration)

// Mark the MigMigration as started once prechecks are passed
r.startMigMigration(migMigration)

// Ensure source cluster has a Velero Backup
r.ensureSourceClusterBackup(migMigration)

// Ensure destination cluster has a Velero Backup + Restore
r.ensureDestinationClusterRestore(migMigration)

// Mark MigMigration as complete if Velero Restore has completed
r.finishMigMigration(migMigration)
```

 - Create `migrate.go` to contain core functionality needed for Migration (Backup + Restore). 
   - Auxiliary functions may fit nicely in other similar go files, e.g. `migrate_registry.go` for Migration tasks related to movement of images between clusters

 - Update comments in `backup.go` and `restore.go` to put resource name in consistent location