### PR TITLE
Add prefix to velero BackupStorageLocation

### DIFF
--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -129,6 +129,7 @@ func (r *MigStorage) updateAwsBSL(location *velero.BackupStorageLocation) {
 	location.Spec.StorageType = velero.StorageType{
 		ObjectStorage: &velero.ObjectStorageLocation{
 			Bucket: config.AwsBucketName,
+			Prefix: "velero",
 		},
 	}
 	location.Spec.Config = map[string]string{


### PR DESCRIPTION
In order to prevent velero validation errors when the backup storage
bucket contains migration registry storage as well, the velero
backups need to be configured to use a directory prefix within
the bucket.

This commit hard-codes that prefix to "velero-backups". A more flexible
approach would add a field to BackupStorageConfig, but that would
probably only be needed if there was some need to have two
completely different sets of velero backups in one bucket. Without that,
this should be sufficient.