### PR TITLE
Lables ref: ObjectMeta.UID

### DIFF
--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -99,7 +99,7 @@ func (r *MigStorage) Equals(a, b *velero.BackupStorageLocation) bool {
 func (r *MigStorage) BuildBSL() *velero.BackupStorageLocation {
 	location := &velero.BackupStorageLocation{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:       CorrelationLabels(r, r.Namespace, r.Name),
+			Labels:       CorrelationLabels(r, r.UID),
 			Namespace:    "velero",
 			GenerateName: r.Name + "-",
 		},
@@ -140,7 +140,7 @@ func (r *MigStorage) updateAwsBSL(location *velero.BackupStorageLocation) {
 // Returns `nil` when not found.
 func (r *MigStorage) GetBSL(client k8sclient.Client) (*velero.BackupStorageLocation, error) {
 	list := velero.BackupStorageLocationList{}
-	labels := CorrelationLabels(r, r.Namespace, r.Name)
+	labels := CorrelationLabels(r, r.UID)
 	err := client.List(
 		context.TODO(),
 		k8sclient.MatchingLabels(labels),

--- a/pkg/apis/migration/v1alpha1/model.go
+++ b/pkg/apis/migration/v1alpha1/model.go
@@ -2,7 +2,6 @@ package v1alpha1
 
 import (
 	"context"
-	"fmt"
 	migref "github.com/fusor/mig-controller/pkg/reference"
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -167,11 +166,10 @@ func GetSecret(client k8sclient.Client, ref *kapi.ObjectReference) (*kapi.Secret
 }
 
 // Build  labels used to correlate CRs.
-// Format: <kind>: <namespace>:<name>
-func CorrelationLabels(kind interface{}, namespace, name string) map[string]string {
-	ref := fmt.Sprintf("%s.%s", namespace, name)
+// Format: <kind>: <uid>.  The <uid> should be the ObjectMeta.UID
+func CorrelationLabels(kind interface{}, uid types.UID) map[string]string {
 	key := strings.ToLower(migref.ToKind(kind))
 	return map[string]string{
-		key: ref,
+		key: string(uid),
 	}
 }


### PR DESCRIPTION
Using the `ObjectMeta.UID` as the _correlation_ label value (instead of namespaced name) resolves the problem created when a CR is re-created with the same name.  The `UID` is auto-generated and designed to identify unique instances of a resource.

[1] https://kubernetes.io/docs/reference/federation/v1/definitions/#_v1_objectmeta