### PR TITLE
MigCluster return local or remote client based on IsHostCluster.

### DIFF
--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -72,14 +72,17 @@ func (m *MigCluster) GetServiceAccountSecret(client k8sclient.Client) (*kapi.Sec
 	return GetSecret(client, m.Spec.ServiceAccountSecretRef)
 }
 
-// BuildControllerRuntimeClient builds a remote client using a MigCluster and an existing client
-func (m *MigCluster) BuildControllerRuntimeClient(c k8sclient.Client) (k8sclient.Client, error) {
+// GetClient get a local or remote client using a MigCluster and an existing client
+func (m *MigCluster) GetClient(c k8sclient.Client) (k8sclient.Client, error) {
+	if m.Spec.IsHostCluster {
+		return c, nil
+	}
 	restConfig, err := m.BuildRestConfig(c)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := buildControllerRuntimeClient(restConfig)
+	client, err := buildClient(restConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -150,9 +153,9 @@ func buildRestConfig(clusterURL string, bearerToken string) *rest.Config {
 	return clusterConfig
 }
 
-// buildControllerRuntimeClient builds a controller-runtime client for interacting with
+// buildClient builds a controller-runtime client for interacting with
 // a K8s cluster.
-func buildControllerRuntimeClient(config *rest.Config) (k8sclient.Client, error) {
+func buildClient(config *rest.Config) (k8sclient.Client, error) {
 	c, err := k8sclient.New(config, k8sclient.Options{Scheme: scheme.Scheme})
 	if err != nil {
 		return nil, err

--- a/pkg/controller/migcluster/validation.go
+++ b/pkg/controller/migcluster/validation.go
@@ -210,7 +210,7 @@ func (r ReconcileMigCluster) testConnection(cluster *migapi.MigCluster) (int, er
 	if cluster.Spec.IsHostCluster {
 		return 0, nil
 	}
-	_, err := cluster.BuildControllerRuntimeClient(r)
+	_, err := cluster.GetClient(r)
 	if err != nil {
 		message := fmt.Sprintf(TestConnectFailedMessage, err)
 		cluster.Status.SetCondition(migapi.Condition{

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -65,7 +65,7 @@ func (r *ReconcileMigMigration) startMigMigration(migMigration *migapi.MigMigrat
 
 func (r *ReconcileMigMigration) ensureSourceClusterBackup(migMigration *migapi.MigMigration, rres *reconcileResources) (*reconcileResources, error) {
 	// Build controller-runtime client for srcMigCluster
-	srcClusterK8sClient, err := rres.srcMigCluster.BuildControllerRuntimeClient(r.Client)
+	srcClusterK8sClient, err := rres.srcMigCluster.GetClient(r.Client)
 	if err != nil {
 		log.Error(err, "[%s] Failed to GET srcClusterK8sClient", logPrefix)
 		return nil, nil // don't requeue
@@ -109,7 +109,7 @@ func (r *ReconcileMigMigration) ensureSourceClusterBackup(migMigration *migapi.M
 
 func (r *ReconcileMigMigration) ensureDestinationClusterRestore(migMigration *migapi.MigMigration, rres *reconcileResources) (*reconcileResources, error) {
 	// Build controller-runtime client for destMigCluster
-	destClusterK8sClient, err := rres.destMigCluster.BuildControllerRuntimeClient(r.Client)
+	destClusterK8sClient, err := rres.destMigCluster.GetClient(r.Client)
 	if err != nil {
 		log.Error(err, "[%s] Failed to GET destClusterK8sClient", logPrefix)
 		return nil, nil // don't requeue

--- a/pkg/controller/migplan/storage.go
+++ b/pkg/controller/migplan/storage.go
@@ -48,14 +48,7 @@ func (r ReconcileMigPlan) createBSLs(plan *migapi.MigPlan) error {
 		return err
 	}
 	for _, cluster := range clusters {
-		if !cluster.Spec.IsHostCluster {
-			client, err = cluster.BuildControllerRuntimeClient(r)
-			if err != nil {
-				return err
-			}
-		} else {
-			client = r
-		}
+		client, err = cluster.GetClient(r)
 		newLocation := storage.BuildBSL()
 		location, err := storage.GetBSL(client)
 		if err != nil {

--- a/pkg/controller/migstorage/storage.go
+++ b/pkg/controller/migstorage/storage.go
@@ -29,7 +29,7 @@ func (r ReconcileMigStorage) deleteBSLs(storage *migapi.MigStorage) error {
 	}
 	for _, cluster := range clusters {
 		if !cluster.Spec.IsHostCluster {
-			client, err = cluster.BuildControllerRuntimeClient(r)
+			client, err = cluster.GetClient(r)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Return the local k8s `Client` or build are _remote_ `Client` based on `MigCluster.IsHostCluster`.

Renamed since it returns a _k8s_ `Client` not specific to _controller-runtime_ as far as I can tell.  Also, the method isn't always building so more ambigious _getting_ a client. 