### PR TITLE
Hack to zap encoder internals to get log messages to align properly

### DIFF
--- a/vendor/go.uber.org/zap/zapcore/encoder.go
+++ b/vendor/go.uber.org/zap/zapcore/encoder.go
@@ -91,8 +91,8 @@ type TimeEncoder func(time.Time, PrimitiveArrayEncoder)
 // since the Unix epoch.
 func EpochTimeEncoder(t time.Time, enc PrimitiveArrayEncoder) {
 	nanos := t.UnixNano()
-	sec := float64(nanos) / float64(time.Second)
-	enc.AppendFloat64(sec)
+	sec := int64(float64(nanos) / float64(time.Second))
+	enc.AppendInt64(sec)
 }
 
 // EpochMillisTimeEncoder serializes a time.Time to a floating-point number of


### PR DESCRIPTION
Small change to the encoder in vendored zap logger used by kubebuilder to remove the variable length decimal epoch time value included with each log message.

Adding this makes logs much more readable. I have spent a small amount of time investigating how to make this change in a more durable way (e.g. changing something within our codebase rather than in a vendored project).

I've just been copying my modified encoder.go into vendor for a while, personally I feel having this in place is worth it despite the fact that it will disappear when we run `dep ensure`. 