### PR TITLE
Registry cluster ref not required for local cluster.

### DIFF
--- a/pkg/apis/migration/v1alpha1/condition.go
+++ b/pkg/apis/migration/v1alpha1/condition.go
@@ -50,6 +50,7 @@ type Conditions struct {
 	Conditions []Condition `json:"conditions"`
 }
 
+// Find a condition by type.
 func (r *Conditions) FindCondition(cndType string) (int, *Condition) {
 	if r.Conditions == nil {
 		return 0, nil

--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,6 +96,10 @@ func (m *MigCluster) BuildRestConfig(c k8sclient.Client) (*rest.Config, error) {
 	// Get first K8s endpoint from ClusterRef
 	clusterRef := m.Spec.ClusterRef
 	cluster := &crapi.Cluster{}
+	if clusterRef == nil {
+		err := errors.New("ClusterRef is nil.")
+		return nil, err
+	}
 
 	err := c.Get(context.TODO(), types.NamespacedName{Name: clusterRef.Name, Namespace: clusterRef.Namespace}, cluster)
 	if err != nil {
@@ -121,6 +126,10 @@ func (m *MigCluster) BuildRestConfig(c k8sclient.Client) (*rest.Config, error) {
 	// Get SA token attached to this MigCluster
 	saSecretRef := m.Spec.ServiceAccountSecretRef
 	saSecret := &kapi.Secret{}
+	if saSecretRef == nil {
+		err := errors.New("ServiceAccountSecretRef not set.")
+		return nil, err
+	}
 
 	err = c.Get(context.TODO(), types.NamespacedName{Name: saSecretRef.Name, Namespace: saSecretRef.Namespace}, saSecret)
 	if err != nil {

--- a/pkg/controller/migcluster/migcluster_controller.go
+++ b/pkg/controller/migcluster/migcluster_controller.go
@@ -25,8 +25,10 @@ import (
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	crapi "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -136,27 +138,34 @@ func (r *ReconcileMigCluster) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Create a Remote Watch for this MigCluster if one doesn't exist
-	if !migCluster.Spec.IsHostCluster {
-		remoteWatchMap := GetRemoteWatchMap()
-		remoteWatchCluster := remoteWatchMap.Get(request.NamespacedName)
+	remoteWatchMap := GetRemoteWatchMap()
+	remoteWatchCluster := remoteWatchMap.Get(request.NamespacedName)
 
-		if remoteWatchCluster == nil {
-			log.Info(fmt.Sprintf("[mCluster] Starting RemoteWatch for MigCluster [%s/%s]", request.Namespace, request.Name))
+	if remoteWatchCluster == nil {
+		log.Info(fmt.Sprintf("[mCluster] Starting RemoteWatch for MigCluster [%s/%s]", request.Namespace, request.Name))
 
-			// restCfg := util.BuildRestConfig(remoteClusterURL, saToken)
-			restCfg, err := migCluster.BuildRestConfig(r.Client)
+		var restCfg *rest.Config
+
+		if migCluster.Spec.IsHostCluster {
+			restCfg, err = config.GetConfig()
 			if err != nil {
-				log.Error(err, fmt.Sprintf("[mCluster] Error during BuildRestConfig for RemoteWatch on MigCluster [%s/%s]", request.Namespace, request.Name))
+				log.Error(err, fmt.Sprintf("[mCluster] Error during config.GetConfig() for RemoteWatch on MigCluster [%s/%s]", request.Namespace, request.Name))
+				return reconcile.Result{}, err
+			}
+		} else {
+			restCfg, err = migCluster.BuildRestConfig(r.Client)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("[mCluster] Error during BuildRestConfig() for RemoteWatch on MigCluster [%s/%s]", request.Namespace, request.Name))
 				return reconcile.Result{}, nil // don't requeue
 			}
-
-			StartRemoteWatch(r, RemoteManagerConfig{
-				RemoteRestConfig: restCfg,
-				ParentNsName:     request.NamespacedName,
-				ParentResource:   migCluster,
-			})
-			log.Info(fmt.Sprintf("[mCluster] RemoteWatch started successfully for MigCluster [%s/%s]", request.Namespace, request.Name))
 		}
+
+		StartRemoteWatch(r, RemoteManagerConfig{
+			RemoteRestConfig: restCfg,
+			ParentNsName:     request.NamespacedName,
+			ParentResource:   migCluster,
+		})
+		log.Info(fmt.Sprintf("[mCluster] RemoteWatch started successfully for MigCluster [%s/%s]", request.Namespace, request.Name))
 	}
 
 	// Done

--- a/pkg/controller/migplan/storage.go
+++ b/pkg/controller/migplan/storage.go
@@ -48,6 +48,9 @@ func (r ReconcileMigPlan) createBSLs(plan *migapi.MigPlan) error {
 		return err
 	}
 	for _, cluster := range clusters {
+		if !cluster.Status.IsReady() {
+			continue
+		}
 		client, err = cluster.GetClient(r)
 		newLocation := storage.BuildBSL()
 		location, err := storage.GetBSL(client)


### PR DESCRIPTION
Make the MigCluster `ClusterRef` and `ServiceAccountSecretRef` optional when `IsHostCluster` is true.