### PR TITLE
Specify includedResources if stageMigration is specified

### DIFF
--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -84,7 +84,9 @@ func (r *ReconcileMigMigration) ensureSourceClusterBackup(migMigration *migapi.M
 			Namespace: migMigration.Status.SrcBackupRef.Namespace,
 		}
 	}
-	srcBackup, err := vrunner.RunBackup(srcClusterK8sClient, backupNsName, rres.migAssets, logPrefix, false)
+
+	vBackup := vrunner.BuildVeleroBackup(backupNsName.Namespace, backupNsName.Name, rres.migAssets.Spec.Namespaces, false)
+	srcBackup, err := vrunner.RunBackup(srcClusterK8sClient, backupNsName, vBackup, logPrefix)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil // don't requeue

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -85,8 +85,8 @@ func (r *ReconcileMigMigration) ensureSourceClusterBackup(migMigration *migapi.M
 		}
 	}
 
-	vBackup := vrunner.BuildVeleroBackup(backupNsName.Namespace, backupNsName.Name, rres.migAssets.Spec.Namespaces, false)
-	srcBackup, err := vrunner.RunBackup(srcClusterK8sClient, backupNsName, vBackup, logPrefix)
+	vBackup := vrunner.BuildVeleroBackup(backupNsName, rres.migAssets.Spec.Namespaces, false)
+	srcBackup, err := vrunner.RunBackup(srcClusterK8sClient, vBackup, logPrefix)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil // don't requeue
@@ -137,7 +137,8 @@ func (r *ReconcileMigMigration) ensureDestinationClusterRestore(migMigration *mi
 		Namespace: migMigration.Status.SrcBackupRef.Namespace,
 	}
 
-	destRestore, err := vrunner.RunRestore(destClusterK8sClient, restoreNsName, backupNsName, logPrefix)
+	vRestoreNew := vrunner.BuildVeleroRestore(restoreNsName, backupNsName.Name)
+	destRestore, err := vrunner.RunRestore(destClusterK8sClient, vRestoreNew, backupNsName, logPrefix)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil // don't requeue

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -84,7 +84,7 @@ func (r *ReconcileMigMigration) ensureSourceClusterBackup(migMigration *migapi.M
 			Namespace: migMigration.Status.SrcBackupRef.Namespace,
 		}
 	}
-	srcBackup, err := vrunner.RunBackup(srcClusterK8sClient, backupNsName, rres.migAssets, logPrefix)
+	srcBackup, err := vrunner.RunBackup(srcClusterK8sClient, backupNsName, rres.migAssets, logPrefix, false)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil // don't requeue

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -86,7 +86,7 @@ func (r *ReconcileMigMigration) ensureSourceClusterBackup(migMigration *migapi.M
 	}
 
 	vBackup := vrunner.BuildVeleroBackup(backupNsName, rres.migAssets.Spec.Namespaces, false)
-	srcBackup, err := vrunner.RunBackup(srcClusterK8sClient, vBackup, logPrefix)
+	srcBackup, err := vrunner.RunBackup(srcClusterK8sClient, vBackup, backupNsName, logPrefix)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil // don't requeue
@@ -138,7 +138,7 @@ func (r *ReconcileMigMigration) ensureDestinationClusterRestore(migMigration *mi
 	}
 
 	vRestoreNew := vrunner.BuildVeleroRestore(restoreNsName, backupNsName.Name)
-	destRestore, err := vrunner.RunRestore(destClusterK8sClient, vRestoreNew, backupNsName, logPrefix)
+	destRestore, err := vrunner.RunRestore(destClusterK8sClient, vRestoreNew, restoreNsName, backupNsName, logPrefix)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil // don't requeue

--- a/pkg/velerorunner/backup.go
+++ b/pkg/velerorunner/backup.go
@@ -32,10 +32,10 @@ import (
 var log = logf.Log.WithName("controller")
 
 // RunBackup runs a Velero Backup if it hasn't been run already
-func RunBackup(c client.Client, backupNsName types.NamespacedName, assets *migapi.MigAssetCollection, logPrefix string) (*velerov1.Backup, error) {
+func RunBackup(c client.Client, backupNsName types.NamespacedName, assets *migapi.MigAssetCollection, logPrefix string, stageBackup bool) (*velerov1.Backup, error) {
 
 	vBackupExisting := &velerov1.Backup{}
-	vBackupNew := buildVeleroBackup(backupNsName.Namespace, backupNsName.Name, assets.Spec.Namespaces)
+	vBackupNew := buildVeleroBackup(backupNsName.Namespace, backupNsName.Name, assets.Spec.Namespaces, stageBackup)
 
 	// Switch over to using a generated name if we are creating
 	// if createNew {

--- a/pkg/velerorunner/backup.go
+++ b/pkg/velerorunner/backup.go
@@ -31,8 +31,7 @@ import (
 var log = logf.Log.WithName("controller")
 
 // RunBackup runs a Velero Backup if it hasn't been run already
-func RunBackup(c client.Client, vBackupNew *velerov1.Backup, logPrefix string) (*velerov1.Backup, error) {
-	backupNsName := types.NamespacedName{Namespace: vBackupNew.Namespace, Name: vBackupNew.Name}
+func RunBackup(c client.Client, vBackupNew *velerov1.Backup, backupNsName types.NamespacedName, logPrefix string) (*velerov1.Backup, error) {
 	vBackupExisting := &velerov1.Backup{}
 
 	err := c.Get(context.TODO(), backupNsName, vBackupExisting)

--- a/pkg/velerorunner/backup.go
+++ b/pkg/velerorunner/backup.go
@@ -31,14 +31,9 @@ import (
 var log = logf.Log.WithName("controller")
 
 // RunBackup runs a Velero Backup if it hasn't been run already
-func RunBackup(c client.Client, backupNsName types.NamespacedName, vBackupNew *velerov1.Backup, logPrefix string) (*velerov1.Backup, error) {
+func RunBackup(c client.Client, vBackupNew *velerov1.Backup, logPrefix string) (*velerov1.Backup, error) {
+	backupNsName := types.NamespacedName{Namespace: vBackupNew.Namespace, Name: vBackupNew.Name}
 	vBackupExisting := &velerov1.Backup{}
-
-	// Switch over to using a generated name if we are creating
-	// if createNew {
-	// 	vBackupNew.ObjectMeta.Name = ""
-	// 	vBackupNew.ObjectMeta.GenerateName = backupNsName.Name
-	// }
 
 	err := c.Get(context.TODO(), backupNsName, vBackupExisting)
 	if err != nil {

--- a/pkg/velerorunner/backup.go
+++ b/pkg/velerorunner/backup.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"reflect"
 
-	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -32,10 +31,8 @@ import (
 var log = logf.Log.WithName("controller")
 
 // RunBackup runs a Velero Backup if it hasn't been run already
-func RunBackup(c client.Client, backupNsName types.NamespacedName, assets *migapi.MigAssetCollection, logPrefix string, stageBackup bool) (*velerov1.Backup, error) {
-
+func RunBackup(c client.Client, backupNsName types.NamespacedName, vBackupNew *velerov1.Backup, logPrefix string) (*velerov1.Backup, error) {
 	vBackupExisting := &velerov1.Backup{}
-	vBackupNew := buildVeleroBackup(backupNsName.Namespace, backupNsName.Name, assets.Spec.Namespaces, stageBackup)
 
 	// Switch over to using a generated name if we are creating
 	// if createNew {

--- a/pkg/velerorunner/builder.go
+++ b/pkg/velerorunner/builder.go
@@ -23,8 +23,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var stageResources = []string{"pods", "persistentvolumes", "persistentvolumeclaims", "imagestreams", "imagestreamtags"}
+
 // buildVeleroBackup creates a Velero backup with default values for most fields
-func buildVeleroBackup(ns string, name string, backupNamespaces []string) *velerov1.Backup {
+func buildVeleroBackup(ns string, name string, backupNamespaces []string, stageBackup bool) *velerov1.Backup {
+	includedResources := []string{}
+	if stageBackup {
+		includedResources = stageResources
+	}
 	backup := &velerov1.Backup{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: name,
@@ -36,7 +42,7 @@ func buildVeleroBackup(ns string, name string, backupNamespaces []string) *veler
 			IncludedNamespaces: backupNamespaces,
 			// Unused but defaulted fields
 			ExcludedNamespaces: []string{},
-			IncludedResources:  []string{},
+			IncludedResources:  includedResources,
 			ExcludedResources:  []string{},
 			Hooks:              velerov1.BackupHooks{Resources: []velerov1.BackupResourceHookSpec{}},
 			// VolumeSnapshotLocations: []string{},

--- a/pkg/velerorunner/builder.go
+++ b/pkg/velerorunner/builder.go
@@ -27,9 +27,9 @@ import (
 var stageResources = []string{"pods", "persistentvolumes", "persistentvolumeclaims", "imagestreams", "imagestreamtags"}
 
 // BuildVeleroBackup creates a Velero backup with default values for most fields
-func BuildVeleroBackup(nsName types.NamespacedName, backupNamespaces []string, stageBackup bool) *velerov1.Backup {
+func BuildVeleroBackup(nsName types.NamespacedName, backupNamespaces []string, isStageBackup bool) *velerov1.Backup {
 	includedResources := []string{}
-	if stageBackup {
+	if isStageBackup {
 		includedResources = stageResources
 	}
 	backup := &velerov1.Backup{

--- a/pkg/velerorunner/builder.go
+++ b/pkg/velerorunner/builder.go
@@ -21,20 +21,21 @@ import (
 
 	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var stageResources = []string{"pods", "persistentvolumes", "persistentvolumeclaims", "imagestreams", "imagestreamtags"}
 
-// buildVeleroBackup creates a Velero backup with default values for most fields
-func BuildVeleroBackup(ns string, name string, backupNamespaces []string, stageBackup bool) *velerov1.Backup {
+// BuildVeleroBackup creates a Velero backup with default values for most fields
+func BuildVeleroBackup(nsName types.NamespacedName, backupNamespaces []string, stageBackup bool) *velerov1.Backup {
 	includedResources := []string{}
 	if stageBackup {
 		includedResources = stageResources
 	}
 	backup := &velerov1.Backup{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: name,
-			Namespace:    ns,
+			GenerateName: nsName.Name,
+			Namespace:    nsName.Namespace,
 		},
 		Spec: velerov1.BackupSpec{
 			StorageLocation:    "default",
@@ -51,15 +52,15 @@ func BuildVeleroBackup(ns string, name string, backupNamespaces []string, stageB
 	return backup
 }
 
-// buildVeleroRestore creates a mostly blank Velero Restore in a specified ns/name, with the
+// BuildVeleroRestore creates a mostly blank Velero Restore in a specified ns/name, with the
 // ability to specify a unique Velero Backup resource name to restore from.
 // TODO: offer more customization
-func buildVeleroRestore(ns string, name string, backupUniqueName string) *velerov1.Restore {
+func BuildVeleroRestore(nsName types.NamespacedName, backupUniqueName string) *velerov1.Restore {
 	restorePVs := true
 	restore := &velerov1.Restore{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: name,
-			Namespace:    ns,
+			GenerateName: nsName.Name,
+			Namespace:    nsName.Namespace,
 		},
 		Spec: velerov1.RestoreSpec{
 			BackupName: backupUniqueName,

--- a/pkg/velerorunner/builder.go
+++ b/pkg/velerorunner/builder.go
@@ -26,7 +26,7 @@ import (
 var stageResources = []string{"pods", "persistentvolumes", "persistentvolumeclaims", "imagestreams", "imagestreamtags"}
 
 // buildVeleroBackup creates a Velero backup with default values for most fields
-func buildVeleroBackup(ns string, name string, backupNamespaces []string, stageBackup bool) *velerov1.Backup {
+func BuildVeleroBackup(ns string, name string, backupNamespaces []string, stageBackup bool) *velerov1.Backup {
 	includedResources := []string{}
 	if stageBackup {
 		includedResources = stageResources

--- a/pkg/velerorunner/restore.go
+++ b/pkg/velerorunner/restore.go
@@ -28,8 +28,7 @@ import (
 )
 
 // RunRestore runs a Velero Restore if it hasn't been run already
-func RunRestore(c client.Client, vRestoreNew *velerov1.Restore, backupNsName types.NamespacedName, logPrefix string) (*velerov1.Restore, error) {
-	restoreNsName := types.NamespacedName{Namespace: vRestoreNew.Namespace, Name: vRestoreNew.Name}
+func RunRestore(c client.Client, vRestoreNew *velerov1.Restore, restoreNsName, backupNsName types.NamespacedName, logPrefix string) (*velerov1.Restore, error) {
 	vRestoreExisting := &velerov1.Restore{}
 
 	err := c.Get(context.TODO(), restoreNsName, vRestoreExisting)

--- a/pkg/velerorunner/restore.go
+++ b/pkg/velerorunner/restore.go
@@ -28,9 +28,8 @@ import (
 )
 
 // RunRestore runs a Velero Restore if it hasn't been run already
-func RunRestore(c client.Client, restoreNsName types.NamespacedName, backupNsName types.NamespacedName, logPrefix string) (*velerov1.Restore, error) {
-
-	vRestoreNew := buildVeleroRestore(restoreNsName.Namespace, restoreNsName.Name, backupNsName.Name)
+func RunRestore(c client.Client, vRestoreNew *velerov1.Restore, backupNsName types.NamespacedName, logPrefix string) (*velerov1.Restore, error) {
+	restoreNsName := types.NamespacedName{Namespace: vRestoreNew.Namespace, Name: vRestoreNew.Name}
 	vRestoreExisting := &velerov1.Restore{}
 
 	err := c.Get(context.TODO(), restoreNsName, vRestoreExisting)


### PR DESCRIPTION
This is needed so that when the stage controller runs `RunBackup` which then calls `buildVeleroBackup` we specify the `includedResources` section to only backup PV data and Imagestreams