### PR TITLE
Manage velero cloud-credentials secret.  AWS only.

### DIFF
--- a/config/samples/cloud-creds.yaml
+++ b/config/samples/cloud-creds.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: mig
+  name: cloud-creds
+type: Opaque
+data:
+  aws-access-key-id: aGVsbG8K
+  aws-secret-access-key: aGVsbG8K
+  azure-client-secret: aGVsbG8K
+  azure-subscription-id: aGVsbG8K
+  azure-tenant-id: aGVsbG8K
+  azure-client-id: aGVsbG8K

--- a/config/samples/mig-storage.yaml
+++ b/config/samples/mig-storage.yaml
@@ -8,22 +8,18 @@ metadata:
 spec:
   backupStorageProvider: aws
   volumeSnapshotProvider: aws
-
   backupStorageConfig:
     awsBucketName: foo
     awsKmsKeyId: foo
     awsPublicUrl: foo
     awsRegion: foo
-    awsSignatureVersion: foo
+    awsSignatureVersion: "4"
     credsSecretRef:
-      namespace: velero
-      name: cloud-credentials
-
-
+      namespace: mig
+      name: cloud-creds
   volumeSnapshotConfig:
     awsRegion: foo
     credsSecretRef:
-      namespace: velero
-      name: cloud-credentials
-
+      namespace: mig
+      name: cloud-creds
 

--- a/pkg/apis/migration/v1alpha1/model.go
+++ b/pkg/apis/migration/v1alpha1/model.go
@@ -165,11 +165,15 @@ func GetSecret(client k8sclient.Client, ref *kapi.ObjectReference) (*kapi.Secret
 	return &object, err
 }
 
+// Get a label (key) for the specified CR kind.
+func Label(r interface{}) string {
+	return strings.ToLower(migref.ToKind(r))
+}
+
 // Build  labels used to correlate CRs.
 // Format: <kind>: <uid>.  The <uid> should be the ObjectMeta.UID
-func CorrelationLabels(kind interface{}, uid types.UID) map[string]string {
-	key := strings.ToLower(migref.ToKind(kind))
+func CorrelationLabels(r interface{}, uid types.UID) map[string]string {
 	return map[string]string{
-		key: string(uid),
+		Label(r): string(uid),
 	}
 }

--- a/pkg/controller/migstorage/predicate.go
+++ b/pkg/controller/migstorage/predicate.go
@@ -2,24 +2,104 @@ package migstorage
 
 import (
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
+	migref "github.com/fusor/mig-controller/pkg/reference"
+	kapi "k8s.io/api/core/v1"
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-type UpdatedPredicate struct {
+type StoragePredicate struct {
 	predicate.Funcs
 }
 
-func (r UpdatedPredicate) Update(e event.UpdateEvent) bool {
-	objectOld, cast := e.ObjectOld.(*migapi.MigStorage)
+func (r StoragePredicate) Create(e event.CreateEvent) bool {
+	storage, cast := e.Object.(*migapi.MigStorage)
+	if cast {
+		r.mapRefs(storage)
+	}
+	return true
+}
+
+func (r StoragePredicate) Update(e event.UpdateEvent) bool {
+	old, cast := e.ObjectOld.(*migapi.MigStorage)
 	if !cast {
 		return true
 	}
-	objectNew, cast := e.ObjectNew.(*migapi.MigStorage)
+	new, cast := e.ObjectNew.(*migapi.MigStorage)
 	if !cast {
 		return true
 	}
-	changed := !reflect.DeepEqual(objectOld.Spec, objectNew.Spec)
+	changed := !reflect.DeepEqual(old.Spec, new.Spec)
+	if changed {
+		r.unmapRefs(old)
+		r.mapRefs(new)
+	}
 	return changed
+}
+
+func (r StoragePredicate) Delete(e event.DeleteEvent) bool {
+	storage, cast := e.Object.(*migapi.MigStorage)
+	if cast {
+		r.unmapRefs(storage)
+	}
+	return true
+}
+
+func (r StoragePredicate) mapRefs(storage *migapi.MigStorage) {
+	refMap := migref.GetMap()
+
+	refOwner := migref.RefOwner{
+		Kind:      migref.ToKind(storage),
+		Namespace: storage.Namespace,
+		Name:      storage.Name,
+	}
+
+	// BSL cred secret
+	ref := storage.Spec.BackupStorageConfig.CredsSecretRef
+	if migref.RefSet(ref) {
+		refMap.Add(refOwner, migref.RefTarget{
+			Kind:      migref.ToKind(kapi.Secret{}),
+			Namespace: ref.Namespace,
+			Name:      ref.Name,
+		})
+	}
+	// VSL cred secret
+	ref = storage.Spec.VolumeSnapshotConfig.CredsSecretRef
+	if migref.RefSet(ref) {
+		refMap.Add(refOwner, migref.RefTarget{
+			Kind:      migref.ToKind(kapi.Secret{}),
+			Namespace: ref.Namespace,
+			Name:      ref.Name,
+		})
+	}
+}
+
+func (r StoragePredicate) unmapRefs(storage *migapi.MigStorage) {
+	refMap := migref.GetMap()
+
+	refOwner := migref.RefOwner{
+		Kind:      migref.ToKind(storage),
+		Namespace: storage.Namespace,
+		Name:      storage.Name,
+	}
+
+	// BSL cred secret
+	ref := storage.Spec.BackupStorageConfig.CredsSecretRef
+	if migref.RefSet(ref) {
+		refMap.Delete(refOwner, migref.RefTarget{
+			Kind:      migref.ToKind(kapi.Secret{}),
+			Namespace: ref.Namespace,
+			Name:      ref.Name,
+		})
+	}
+	// VSL cred secret
+	ref = storage.Spec.VolumeSnapshotConfig.CredsSecretRef
+	if migref.RefSet(ref) {
+		refMap.Delete(refOwner, migref.RefTarget{
+			Kind:      migref.ToKind(kapi.Secret{}),
+			Namespace: ref.Namespace,
+			Name:      ref.Name,
+		})
+	}
 }

--- a/pkg/controller/migstorage/validation.go
+++ b/pkg/controller/migstorage/validation.go
@@ -226,7 +226,7 @@ func (r ReconcileMigStorage) validateBSLCredsSecret(storage *migapi.MigStorage) 
 	}
 
 	// secret content
-	if !r.validCredsSecret(secret) {
+	if !r.validCredSecret(secret) {
 		storage.Status.SetCondition(migapi.Condition{
 			Type:    InvalidBSLCredsSecret,
 			Status:  True,
@@ -371,7 +371,7 @@ func (r ReconcileMigStorage) validateVSLCredsSecret(storage *migapi.MigStorage) 
 	}
 
 	// secret content
-	if !r.validCredsSecret(secret) {
+	if !r.validCredSecret(secret) {
 		storage.Status.SetCondition(migapi.Condition{
 			Type:    InvalidVSLCredsSecret,
 			Status:  True,
@@ -386,7 +386,7 @@ func (r ReconcileMigStorage) validateVSLCredsSecret(storage *migapi.MigStorage) 
 	return 0, nil
 }
 
-func (r ReconcileMigStorage) validCredsSecret(secret *kapi.Secret) bool {
+func (r ReconcileMigStorage) validCredSecret(secret *kapi.Secret) bool {
 	// TODO: waiting on secret layout.
 	return true
 }

--- a/pkg/controller/remotewatcher/predicate.go
+++ b/pkg/controller/remotewatcher/predicate.go
@@ -1,0 +1,51 @@
+package remotewatcher
+
+import (
+	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
+	kapi "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// Correlation labels.
+var labels = map[string]bool{
+	migapi.Label(migapi.MigPlan{}):            true,
+	migapi.Label(migapi.MigCluster{}):         true,
+	migapi.Label(migapi.MigStorage{}):         true,
+	migapi.Label(migapi.MigAssetCollection{}): true,
+	migapi.Label(migapi.MigMigration{}):       true,
+	migapi.Label(migapi.MigStage{}):           true,
+}
+
+type SecretPredicate struct {
+	predicate.Funcs
+}
+
+// Watched resource has been updated.
+func (r SecretPredicate) Update(e event.UpdateEvent) bool {
+	secret, cast := e.ObjectOld.(*kapi.Secret)
+	if cast {
+		return hasCorrelationLabel(secret)
+	}
+	return false
+}
+
+// Watched resource has been deleted.
+func (r SecretPredicate) Delete(e event.DeleteEvent) bool {
+	secret, cast := e.Object.(*kapi.Secret)
+	if cast {
+		return hasCorrelationLabel(secret)
+	}
+	return false
+}
+
+// The watched object has a correlation label.
+func hasCorrelationLabel(secret *kapi.Secret) bool {
+	for label := range secret.Labels {
+		_, found := labels[label]
+		if found {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/remotewatcher/remotewatcher_controller.go
+++ b/pkg/controller/remotewatcher/remotewatcher_controller.go
@@ -15,8 +15,8 @@ package remotewatcher
 
 import (
 	"fmt"
-
 	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
+	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -59,6 +59,10 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 	err = c.Watch(&source.Kind{Type: &velerov1.VolumeSnapshotLocation{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+	err = c.Watch(&source.Kind{Type: &kapi.Secret{}}, &handler.EnqueueRequestForObject{}, &SecretPredicate{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Manages the velero cloud-credentials secret based on the migration plan and BSL configuration in the related storage.  After velero is updated to support multiple profiles, this logic will be updated to manage the sections in the file contained in the secret with more precision.

Adds watch on referenced `CredsSecretRef`.
Adds remote watch on `Secret` with a predicate used to permit only resources containing our _correlation_ label.  This is a general approach that should be expanded to include all of the remote watched resources.