### PR TITLE
Temporary fix to handle multiple snapshot locations

### DIFF
--- a/pkg/velerorunner/builder.go
+++ b/pkg/velerorunner/builder.go
@@ -42,11 +42,11 @@ func BuildVeleroBackup(nsName types.NamespacedName, backupNamespaces []string, i
 			TTL:                metav1.Duration{Duration: 720 * time.Hour},
 			IncludedNamespaces: backupNamespaces,
 			// Unused but defaulted fields
-			ExcludedNamespaces: []string{},
-			IncludedResources:  includedResources,
-			ExcludedResources:  []string{},
-			Hooks:              velerov1.BackupHooks{Resources: []velerov1.BackupResourceHookSpec{}},
-			// VolumeSnapshotLocations: []string{},
+			ExcludedNamespaces:      []string{},
+			IncludedResources:       includedResources,
+			ExcludedResources:       []string{},
+			Hooks:                   velerov1.BackupHooks{Resources: []velerov1.BackupResourceHookSpec{}},
+			VolumeSnapshotLocations: []string{"aws-default"},
 		},
 	}
 	return backup


### PR DESCRIPTION
Now that we're creating multiple snapshot locations, we have to
specify which one to use for the velero backup. This is temporary
fix that just explicitly lists the existing aws-default one.

The longer-term fix is to specify the one we created for the migration.