### PR TITLE
Velero runner improved.

### DIFF
--- a/pkg/apis/migration/v1alpha1/labels.go
+++ b/pkg/apis/migration/v1alpha1/labels.go
@@ -1,0 +1,30 @@
+package v1alpha1
+
+import (
+	migref "github.com/fusor/mig-controller/pkg/reference"
+	"k8s.io/apimachinery/pkg/types"
+	"strings"
+)
+
+// All known correlation labels.
+var KnownLabels = map[string]bool{
+	label(MigPlan{}):            true,
+	label(MigCluster{}):         true,
+	label(MigStorage{}):         true,
+	label(MigAssetCollection{}): true,
+	label(MigMigration{}):       true,
+	label(MigStage{}):           true,
+}
+
+// Build  labels used to correlate CRs.
+// Format: <kind>: <uid>.  The <uid> should be the ObjectMeta.UID
+func buildCorrelationLabels(r interface{}, uid types.UID) map[string]string {
+	return map[string]string{
+		label(r): string(uid),
+	}
+}
+
+// Get a label (key) for the specified CR kind.
+func label(r interface{}) string {
+	return strings.ToLower(migref.ToKind(r))
+}

--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -35,15 +35,10 @@ type MigMigrationSpec struct {
 // MigMigrationStatus defines the observed state of MigMigration
 type MigMigrationStatus struct {
 	Conditions
-
-	MigrationRunning   bool `json:"migrationStarted,omitempty"`
-	MigrationCompleted bool `json:"migrationCompleted,omitempty"`
-
+	MigrationRunning    bool         `json:"migrationStarted,omitempty"`
+	MigrationCompleted  bool         `json:"migrationCompleted,omitempty"`
 	StartTimestamp      *metav1.Time `json:"startTimestamp,omitempty"`
 	CompletionTimestamp *metav1.Time `json:"completionTimestamp,omitempty"`
-
-	SrcBackupRef   *kapi.ObjectReference `json:"srcBackupRef,omitempty"`
-	DestRestoreRef *kapi.ObjectReference `json:"destRestoreRef,omitempty"`
 }
 
 // +genclient
@@ -98,4 +93,9 @@ func (r *MigMigration) MarkAsCompleted() bool {
 	r.Status.MigrationCompleted = true
 	r.Status.CompletionTimestamp = &metav1.Time{Time: time.Now()}
 	return true
+}
+
+// Get whether the the migration has completed.
+func (r *MigMigration) IsCompleted() bool {
+	return r.Status.MigrationCompleted
 }

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -93,6 +93,7 @@ func (r *MigPlan) GetAssetCollection(client k8sclient.Client) (*MigAssetCollecti
 type PlanRefResources struct {
 	MigPlan        *MigPlan
 	MigAssets      *MigAssetCollection
+	MigStorage     *MigStorage
 	SrcMigCluster  *MigCluster
 	DestMigCluster *MigCluster
 
@@ -115,6 +116,15 @@ func (r *MigPlan) GetRefResources(client k8sclient.Client, logPrefix string) (*P
 		return nil, err
 	}
 	resources.MigAssets = migAssets
+
+	// MigStorage
+	storage, err := r.GetStorage(client)
+	if err != nil {
+		log.Info(fmt.Sprintf("[%s] Failed to GET MigAssetCollection referenced by MigStorage [%s/%s]",
+			logPrefix, r.Namespace, r.Name))
+		return nil, err
+	}
+	resources.MigStorage = storage
 
 	// SrcMigCluster
 	srcMigCluster, err := r.GetSourceCluster(client)

--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -125,7 +125,7 @@ func (r *MigStorage) EqualsVSL(a, b *velero.VolumeSnapshotLocation) bool {
 func (r *MigStorage) BuildBSL() *velero.BackupStorageLocation {
 	location := &velero.BackupStorageLocation{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:       CorrelationLabels(r, r.UID),
+			Labels:       r.GetCorrelationLabels(),
 			Namespace:    "velero",
 			GenerateName: r.Name + "-",
 		},
@@ -180,7 +180,7 @@ func (r *MigStorage) updateAwsBSL(location *velero.BackupStorageLocation) {
 // Returns `nil` when not found.
 func (r *MigStorage) GetBSL(client k8sclient.Client) (*velero.BackupStorageLocation, error) {
 	list := velero.BackupStorageLocationList{}
-	labels := CorrelationLabels(r, r.UID)
+	labels := r.GetCorrelationLabels()
 	err := client.List(
 		context.TODO(),
 		k8sclient.MatchingLabels(labels),
@@ -199,7 +199,7 @@ func (r *MigStorage) GetBSL(client k8sclient.Client) (*velero.BackupStorageLocat
 func (r *MigStorage) BuildVSL() *velero.VolumeSnapshotLocation {
 	location := &velero.VolumeSnapshotLocation{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:       CorrelationLabels(r, r.UID),
+			Labels:       r.GetCorrelationLabels(),
 			Namespace:    "velero",
 			GenerateName: r.Name + "-",
 		},
@@ -235,7 +235,7 @@ func (r *MigStorage) updateAwsVSL(location *velero.VolumeSnapshotLocation) {
 // Returns `nil` when not found.
 func (r *MigStorage) GetVSL(client k8sclient.Client) (*velero.VolumeSnapshotLocation, error) {
 	list := velero.VolumeSnapshotLocationList{}
-	labels := CorrelationLabels(r, r.UID)
+	labels := r.GetCorrelationLabels()
 	err := client.List(
 		context.TODO(),
 		k8sclient.MatchingLabels(labels),
@@ -270,7 +270,7 @@ func (r *MigStorage) GetCloudSecret(client k8sclient.Client) (*kapi.Secret, erro
 func (r *MigStorage) BuildCloudSecret(client k8sclient.Client) (*kapi.Secret, error) {
 	secret := &kapi.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:    CorrelationLabels(r, r.ObjectMeta.UID),
+			Labels:    r.GetCorrelationLabels(),
 			Namespace: "velero",
 			Name:      "cloud-credentials",
 		},

--- a/pkg/apis/migration/v1alpha1/model.go
+++ b/pkg/apis/migration/v1alpha1/model.go
@@ -2,12 +2,10 @@ package v1alpha1
 
 import (
 	"context"
-	migref "github.com/fusor/mig-controller/pkg/reference"
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
 //
@@ -163,17 +161,4 @@ func GetSecret(client k8sclient.Client, ref *kapi.ObjectReference) (*kapi.Secret
 	}
 
 	return &object, err
-}
-
-// Get a label (key) for the specified CR kind.
-func Label(r interface{}) string {
-	return strings.ToLower(migref.ToKind(r))
-}
-
-// Build  labels used to correlate CRs.
-// Format: <kind>: <uid>.  The <uid> should be the ObjectMeta.UID
-func CorrelationLabels(r interface{}, uid types.UID) map[string]string {
-	return map[string]string{
-		Label(r): string(uid),
-	}
 }

--- a/pkg/apis/migration/v1alpha1/resource.go
+++ b/pkg/apis/migration/v1alpha1/resource.go
@@ -1,0 +1,86 @@
+package v1alpha1
+
+// Migration application CR.
+type MigResource interface {
+	GetCorrelationLabels() map[string]string
+	GetNamespace() string
+	GetName() string
+}
+
+// Plan
+func (r *MigPlan) GetCorrelationLabels() map[string]string {
+	return buildCorrelationLabels(r, r.UID)
+}
+
+func (r *MigPlan) GetNamespace() string {
+	return r.Namespace
+}
+
+func (r *MigPlan) GetName() string {
+	return r.Name
+}
+
+// AssetCollection
+func (r *MigAssetCollection) GetCorrelationLabels() map[string]string {
+	return buildCorrelationLabels(r, r.UID)
+}
+
+func (r *MigAssetCollection) GetNamespace() string {
+	return r.Namespace
+}
+
+func (r *MigAssetCollection) GetName() string {
+	return r.Name
+}
+
+// Storage
+func (r *MigStorage) GetCorrelationLabels() map[string]string {
+	return buildCorrelationLabels(r, r.UID)
+}
+
+func (r *MigStorage) GetNamespace() string {
+	return r.Namespace
+}
+
+func (r *MigStorage) GetName() string {
+	return r.Name
+}
+
+// Cluster
+func (r *MigCluster) GetCorrelationLabels() map[string]string {
+	return buildCorrelationLabels(r, r.UID)
+}
+
+func (r *MigCluster) GetNamespace() string {
+	return r.Namespace
+}
+
+func (r *MigCluster) GetName() string {
+	return r.Name
+}
+
+// Migration
+func (r *MigMigration) GetCorrelationLabels() map[string]string {
+	return buildCorrelationLabels(r, r.UID)
+}
+
+func (r *MigMigration) GetNamespace() string {
+	return r.Namespace
+}
+
+func (r *MigMigration) GetName() string {
+	return r.Name
+}
+
+// Stage
+func (r *MigStage) GetCorrelationLabels() map[string]string {
+	return buildCorrelationLabels(r, r.UID)
+}
+
+func (r *MigStage) GetNamespace() string {
+	return r.Namespace
+}
+
+func (r *MigStage) GetName() string {
+	return r.Name
+}

--- a/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
@@ -383,16 +383,6 @@ func (in *MigMigrationStatus) DeepCopyInto(out *MigMigrationStatus) {
 		in, out := &in.CompletionTimestamp, &out.CompletionTimestamp
 		*out = (*in).DeepCopy()
 	}
-	if in.SrcBackupRef != nil {
-		in, out := &in.SrcBackupRef, &out.SrcBackupRef
-		*out = new(v1.ObjectReference)
-		**out = **in
-	}
-	if in.DestRestoreRef != nil {
-		in, out := &in.DestRestoreRef, &out.DestRestoreRef
-		*out = new(v1.ObjectReference)
-		**out = **in
-	}
 	return
 }
 
@@ -744,6 +734,11 @@ func (in *PlanRefResources) DeepCopyInto(out *PlanRefResources) {
 	if in.MigAssets != nil {
 		in, out := &in.MigAssets, &out.MigAssets
 		*out = new(MigAssetCollection)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.MigStorage != nil {
+		in, out := &in.MigStorage, &out.MigStorage
+		*out = new(MigStorage)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.SrcMigCluster != nil {

--- a/pkg/controller/migassetcollection/migassetcollection_controller.go
+++ b/pkg/controller/migassetcollection/migassetcollection_controller.go
@@ -34,7 +34,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 )
 
-var log = logf.Log.WithName("controller")
+var log = logf.Log.WithName("asset-collection")
 
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -18,144 +18,60 @@ package migmigration
 
 import (
 	"context"
-	"fmt"
-
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	vrunner "github.com/fusor/mig-controller/pkg/velerorunner"
-	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
-	kapi "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
-func (r *ReconcileMigMigration) precheck(migMigration *migapi.MigMigration) bool {
-	// Return false if MigMigration is already complete
-	if migMigration.Status.MigrationCompleted == true {
-		return false
+func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) error {
+	if migration.IsCompleted() {
+		return nil
 	}
-	// Return false if MigMigration isn't ready
-	if !migMigration.Status.IsReady() {
-		return false
-	}
-	// Return true is everything looks ready to run
-	return true
-}
 
-func (r *ReconcileMigMigration) getResources(migMigration *migapi.MigMigration) (*migapi.PlanRefResources, error) {
-	// Build ReconcileResources for MigMigration containing data needed for rest of reconcile process
-	migPlan, err := migMigration.GetPlan(r.Client)
+	// Ready
+	plan, err := migration.GetPlan(r)
 	if err != nil {
-		log.Info(fmt.Sprintf("[%s] Failed to GET MigPlan referenced by MigMigration [%s/%s]",
-			logPrefix, migMigration.Namespace, migMigration.Name))
-		return nil, err
+		return err
+	}
+	if !plan.Status.IsReady() {
+		log.Info("Plan not ready.", "name", migration.Name)
+		return err
 	}
 
-	rres, err := migPlan.GetRefResources(r.Client, logPrefix)
-	return rres, nil // continue
-}
-
-func (r *ReconcileMigMigration) startMigMigration(migMigration *migapi.MigMigration, rres *migapi.PlanRefResources) (*migapi.PlanRefResources, error) {
-	// If all references are marked as ready, run MarkAsRunning() to set this Migration into "Running" state
-	changed := migMigration.MarkAsRunning()
-	if changed {
-		err := r.Update(context.TODO(), migMigration)
+	// Started
+	if !migration.Status.MigrationRunning {
+		log.Info("Migration started.", "name", migration.Name)
+		migration.MarkAsRunning()
+		err = r.Update(context.TODO(), migration)
 		if err != nil {
-			log.Info("[%s] Failed to mark MigMigration [%s/%s] as running", logPrefix, migMigration.Namespace, migMigration.Name)
-			return nil, err // requeue
-		}
-		log.Info(fmt.Sprintf("[%s] STARTED MigMigration [%s/%s]", logPrefix, migMigration.Namespace, migMigration.Name))
-	}
-	return rres, nil // continue
-}
-
-func getSrcBackupName(migMigration *migapi.MigMigration) types.NamespacedName {
-	var backupNsName types.NamespacedName
-	if migMigration.Status.SrcBackupRef == nil {
-		backupNsName = types.NamespacedName{
-			Name:      migMigration.Name + "-",
-			Namespace: veleroNs,
-		}
-	} else {
-		backupNsName = types.NamespacedName{
-			Name:      migMigration.Status.SrcBackupRef.Name,
-			Namespace: migMigration.Status.SrcBackupRef.Namespace,
+			return err
 		}
 	}
-	return backupNsName
-}
 
-// Create Velero Backup on srcCluster looking at namespaces in MigAssetCollection
-func (r *ReconcileMigMigration) ensureSrcBackup(migMigration *migapi.MigMigration, rres *migapi.PlanRefResources) (*migapi.PlanRefResources, error) {
-	// Determine appropriate backupNsName to use in ensureBackup
-	backupNsName := getSrcBackupName(migMigration)
-
-	// Ensure that a backup exists with backupNsName
-	rres, err := vrunner.EnsureBackup(r.Client, backupNsName, rres, false, logPrefix)
+	// Run
+	planResources, err := plan.GetRefResources(r, "deprecated")
 	if err != nil {
-		return nil, err // requeue
+		return err
 	}
-
-	// Update MigMigration with reference to Velero Backup
-	migMigration.Status.SrcBackupRef = &kapi.ObjectReference{Name: rres.SrcBackup.Name, Namespace: rres.SrcBackup.Namespace}
-	err = r.Update(context.TODO(), migMigration)
+	task := vrunner.Task{
+		Log:           log,
+		Client:        r,
+		Owner:         migration,
+		PlanResources: planResources,
+	}
+	completed, err := task.Run()
 	if err != nil {
-		log.Info(fmt.Sprintf("[%s] Failed to UPDATE MigMigration with Velero Backup reference", logPrefix))
-		return nil, err // requeue
+		return err
 	}
 
-	return rres, nil // continue
-}
-
-func getDestRestoreName(migMigration *migapi.MigMigration) types.NamespacedName {
-	var restoreNsName types.NamespacedName
-	if migMigration.Status.DestRestoreRef == nil {
-		restoreNsName = types.NamespacedName{
-			Name:      migMigration.Name + "-",
-			Namespace: veleroNs,
-		}
-	} else {
-		restoreNsName = types.NamespacedName{
-			Name:      migMigration.Status.DestRestoreRef.Name,
-			Namespace: migMigration.Status.DestRestoreRef.Namespace,
+	// Completed
+	if completed {
+		log.Info("Migration completed.", "name", migration.Name)
+		migration.MarkAsCompleted()
+		err = r.Update(context.TODO(), migration)
+		if err != nil {
+			return err
 		}
 	}
-	return restoreNsName
-}
 
-// Create Velero Restore on destMigCluster pointing at Velero Backup unique name
-func (r *ReconcileMigMigration) ensureDestRestore(migMigration *migapi.MigMigration, rres *migapi.PlanRefResources) (*migapi.PlanRefResources, error) {
-	backupNsName := getSrcBackupName(migMigration)
-	restoreNsName := getDestRestoreName(migMigration)
-
-	rres, err := vrunner.EnsureRestore(r.Client, backupNsName, restoreNsName, rres, logPrefix)
-	if err != nil {
-		return nil, err // requeue
-	}
-	if rres == nil {
-		return nil, nil // don't requeue
-	}
-
-	// Update MigMigration with reference to Velero Retore
-	migMigration.Status.DestRestoreRef = &kapi.ObjectReference{Name: rres.DestRestore.Name, Namespace: rres.DestRestore.Namespace}
-	err = r.Update(context.TODO(), migMigration)
-	if err != nil {
-		log.Info(fmt.Sprintf("[%s] Failed to UPDATE MigMigration with Velero Restore reference", logPrefix))
-		return nil, err // requeue
-	}
-
-	return rres, nil // continue
-}
-
-func (r *ReconcileMigMigration) finishMigMigration(migMigration *migapi.MigMigration, rres *migapi.PlanRefResources) (*migapi.PlanRefResources, error) {
-	if rres.DestRestore.Status.Phase == velerov1.RestorePhaseCompleted {
-		changed := migMigration.MarkAsCompleted()
-		if changed {
-			err := r.Update(context.TODO(), migMigration)
-			if err != nil {
-				log.Info("[%s] Failed to mark MigMigration [%s/%s] as completed", logPrefix, migMigration.Namespace, migMigration.Name)
-				return nil, err // requeue
-			}
-			log.Info(fmt.Sprintf("[%s] FINISHED MigMigration [%s/%s]", logPrefix, migMigration.Namespace, migMigration.Name))
-		}
-	}
-	return rres, nil // continue
+	return nil
 }

--- a/pkg/controller/migstage/migstage_controller.go
+++ b/pkg/controller/migstage/migstage_controller.go
@@ -18,8 +18,6 @@ package migstage
 
 import (
 	"context"
-	"fmt"
-
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -33,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("controller")
+var log = logf.Log.WithName("stage")
 
 const logPrefix = "mStage"
 
@@ -115,7 +113,8 @@ type ReconcileMigStage struct {
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migstages,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migstages/status,verbs=get;update;patch
 func (r *ReconcileMigStage) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.Info(fmt.Sprintf("[%s] RECONCILE [%s/%s]", logPrefix, request.Namespace, request.Name))
+	log.Info("Reconcile", "request", request)
+
 	// Fetch the MigStage instance
 	migStage := &migapi.MigStage{}
 	err := r.Get(context.TODO(), request.NamespacedName, migStage)
@@ -132,7 +131,11 @@ func (r *ReconcileMigStage) Reconcile(request reconcile.Request) (reconcile.Resu
 	// Validate
 	_, err = r.validate(migStage)
 	if err != nil {
-		return reconcile.Result{}, err
+		if errors.IsConflict(err) {
+			return reconcile.Result{Requeue: true}, nil
+		} else {
+			return reconcile.Result{}, err
+		}
 	}
 
 	// Check if validations passed and Stage Migration is ready to run

--- a/pkg/controller/migstorage/migstorage_controller.go
+++ b/pkg/controller/migstorage/migstorage_controller.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("controller")
+var log = logf.Log.WithName("storage")
 
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
@@ -97,7 +97,7 @@ type ReconcileMigStorage struct {
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migstorages,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migstorages/status,verbs=get;update;patch
 func (r *ReconcileMigStorage) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.Info("[mStorage] RECONCILE() ", "request", request)
+	log.Info("Reconcile", "request", request)
 
 	// Fetch the MigStorage instance
 	storage := &migapi.MigStorage{}
@@ -115,7 +115,11 @@ func (r *ReconcileMigStorage) Reconcile(request reconcile.Request) (reconcile.Re
 	// Validations.
 	_, err = r.validate(storage)
 	if err != nil {
-		return reconcile.Result{}, err
+		if errors.IsConflict(err) {
+			return reconcile.Result{Requeue: true}, nil
+		} else {
+			return reconcile.Result{}, err
+		}
 	}
 
 	// Done

--- a/pkg/controller/remotewatcher/predicate.go
+++ b/pkg/controller/remotewatcher/predicate.go
@@ -7,16 +7,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// Correlation labels.
-var labels = map[string]bool{
-	migapi.Label(migapi.MigPlan{}):            true,
-	migapi.Label(migapi.MigCluster{}):         true,
-	migapi.Label(migapi.MigStorage{}):         true,
-	migapi.Label(migapi.MigAssetCollection{}): true,
-	migapi.Label(migapi.MigMigration{}):       true,
-	migapi.Label(migapi.MigStage{}):           true,
-}
-
 type SecretPredicate struct {
 	predicate.Funcs
 }
@@ -42,7 +32,7 @@ func (r SecretPredicate) Delete(e event.DeleteEvent) bool {
 // The watched object has a correlation label.
 func hasCorrelationLabel(secret *kapi.Secret) bool {
 	for label := range secret.Labels {
-		_, found := labels[label]
+		_, found := migapi.KnownLabels[label]
 		if found {
 			return true
 		}

--- a/pkg/controller/remotewatcher/remotewatcher_controller.go
+++ b/pkg/controller/remotewatcher/remotewatcher_controller.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("controller")
+var log = logf.Log.WithName("remote-watch")
 
 // Add creates a new RemoteWatcher Controller with a forwardChannel
 func Add(mgr manager.Manager, forwardChannel chan event.GenericEvent, fowardEvent event.GenericEvent) error {
@@ -83,7 +83,7 @@ type ReconcileRemoteWatcher struct {
 
 // Reconcile reads that state of the cluster for a RemoteWatcher object and makes changes
 func (r *ReconcileRemoteWatcher) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.Info(fmt.Sprintf("[rWatch] Forward reconcile to MigCluster: [%s/%s] <= [%s/%s]",
+	log.Info(fmt.Sprintf("Forward reconcile to MigCluster: [%s/%s] <= [%s/%s]",
 		r.ForwardEvent.Meta.GetNamespace(), r.ForwardEvent.Meta.GetName(), request.Namespace, request.Name))
 
 	// Forward a known Event back to the parent controller

--- a/pkg/velerorunner/task.go
+++ b/pkg/velerorunner/task.go
@@ -1,0 +1,382 @@
+package velerorunner
+
+import (
+	"context"
+	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/go-logr/logr"
+	velero "github.com/heptio/velero/pkg/apis/velero/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+var VeleroNamespace = "velero"
+
+// A Velero task that provides the complete backup & restore workflow.
+// Log - A controller's logger.
+// Client - A controller's (local) client.
+// Owner - A MigStage or MigMigration resource.
+// PlanResources - A PlanRefResources.
+// BackupResources - Resource types to be included in the backup.
+// Backup - A Backup created on the source cluster.
+// Restore - A Restore created on the destination cluster.
+// ClientCache - Client cache keyed by cluster.
+type Task struct {
+	Log             logr.Logger
+	Client          k8sclient.Client
+	Owner           migapi.MigResource
+	PlanResources   *migapi.PlanRefResources
+	BackupResources []string
+	Backup          *velero.Backup
+	Restore         *velero.Restore
+	ClientCache     map[*migapi.MigCluster]k8sclient.Client
+}
+
+// Reconcile() Example:
+//
+// task := velerorunner.Task{
+//     Log: log,
+//     Client: r,
+//     Owner: migration,
+//     PlanResources: plan.GetPlanResources(),
+// }
+//
+// completed, err := task.Run()
+//
+
+// Run the task.
+// Return `true` when run to completion.
+func (t *Task) Run() (bool, error) {
+	// Backup
+	err := t.ensureBackup()
+	if err != nil {
+		return false, err
+	}
+	if t.Backup.Status.Phase != velero.BackupPhaseCompleted {
+		t.Log.Info(
+			"Waiting for backup to complete.",
+			"owner",
+			t.Owner.GetName(),
+			"backup",
+			t.Backup.Name)
+		return false, nil
+	}
+	t.Log.Info(
+		"Backup has completed.",
+		"owner",
+		t.Owner.GetName(),
+		"backup",
+		t.Backup.Name)
+
+	backup, err := t.getReplicatedBackup()
+	if err != nil {
+		return false, err
+	}
+	if backup == nil {
+		t.Log.Info(
+			"Waiting for backup to be replicated to the destination.",
+			"owner",
+			t.Owner.GetName(),
+			"backup",
+			t.Backup.Name)
+		return false, nil
+	}
+	// Restore
+	err = t.ensureRestore()
+	if err != nil {
+		return false, err
+	}
+	if t.Restore.Status.Phase != velero.RestorePhaseCompleted {
+		t.Log.Info(
+			"Waiting for restore to complete.",
+			"owner",
+			t.Owner.GetName(),
+			"restore",
+			t.Restore.Name)
+		return false, nil
+	}
+	t.Log.Info(
+		"Restore has completed.",
+		"owner",
+		t.Owner.GetName(),
+		"restore",
+		t.Restore.Name)
+
+	return true, nil
+}
+
+// Ensure the backup on the source cluster has been created
+// and has the proper settings.
+func (t *Task) ensureBackup() error {
+	newBackup, err := t.buildBackup()
+	if err != nil {
+		return err
+	}
+	foundBackup, err := t.getBackup()
+	if err != nil {
+		return err
+	}
+	if foundBackup == nil {
+		t.Backup = newBackup
+		client, err := t.getSourceClient()
+		if err != nil {
+			return err
+		}
+		err = client.Create(context.TODO(), newBackup)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	t.Backup = foundBackup
+	if !t.equalsBackup(newBackup, foundBackup) {
+		client, err := t.getSourceClient()
+		if err != nil {
+			return err
+		}
+		t.updateBackup(foundBackup)
+		err = client.Update(context.TODO(), foundBackup)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Get whether the two Backups are equal.
+func (t *Task) equalsBackup(a, b *velero.Backup) bool {
+	match := a.Spec.StorageLocation == b.Spec.StorageLocation &&
+		reflect.DeepEqual(a.Spec.VolumeSnapshotLocations, b.Spec.VolumeSnapshotLocations) &&
+		reflect.DeepEqual(a.Spec.IncludedNamespaces, b.Spec.IncludedNamespaces) &&
+		reflect.DeepEqual(a.Spec.IncludedResources, b.Spec.IncludedResources) &&
+		a.Spec.TTL == b.Spec.TTL
+	return match
+}
+
+// Get an existing Backup on the source cluster.
+func (t Task) getBackup() (*velero.Backup, error) {
+	client, err := t.getSourceClient()
+	if err != nil {
+		return nil, err
+	}
+	list := velero.BackupList{}
+	labels := t.Owner.GetCorrelationLabels()
+	err = client.List(
+		context.TODO(),
+		k8sclient.MatchingLabels(labels),
+		&list)
+	if err != nil {
+		return nil, err
+	}
+	if len(list.Items) > 0 {
+		return &list.Items[0], nil
+	}
+
+	return nil, nil
+}
+
+// Get the existing BackupStorageLocation on the source cluster.
+func (t *Task) getBSL() (*velero.BackupStorageLocation, error) {
+	client, err := t.getSourceClient()
+	if err != nil {
+		return nil, err
+	}
+	storage := t.PlanResources.MigStorage
+	location, err := storage.GetBSL(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return location, nil
+}
+
+// Get the existing VolumeSnapshotLocation on the source cluster
+func (t *Task) getVSL() (*velero.VolumeSnapshotLocation, error) {
+	client, err := t.getSourceClient()
+	if err != nil {
+		return nil, err
+	}
+	storage := t.PlanResources.MigStorage
+	location, err := storage.GetVSL(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return location, nil
+}
+
+// Build a Backups as desired for the source cluster.
+func (t *Task) buildBackup() (*velero.Backup, error) {
+	backup := &velero.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:       t.Owner.GetCorrelationLabels(),
+			GenerateName: t.Owner.GetName() + "-",
+			Namespace:    VeleroNamespace,
+		},
+	}
+	err := t.updateBackup(backup)
+	return backup, err
+}
+
+// Update a Backups as desired for the source cluster.
+func (t *Task) updateBackup(backup *velero.Backup) error {
+	namespaces := t.PlanResources.MigAssets.Spec.Namespaces
+	backupLocation, err := t.getBSL()
+	if err != nil {
+		return err
+	}
+	backup.Spec = velero.BackupSpec{
+		StorageLocation:         backupLocation.Name,
+		VolumeSnapshotLocations: []string{"aws-default"},
+		TTL:                     metav1.Duration{Duration: 720 * time.Hour},
+		IncludedNamespaces:      namespaces,
+		ExcludedNamespaces:      []string{},
+		IncludedResources:       t.BackupResources,
+		ExcludedResources:       []string{},
+		Hooks: velero.BackupHooks{
+			Resources: []velero.BackupResourceHookSpec{},
+		},
+	}
+
+	return nil
+}
+
+// Ensure the restore on the destination cluster has been
+// created  and has the proper settings.
+func (t *Task) ensureRestore() error {
+	newRestore := t.buildRestore()
+	foundRestore, err := t.getRestore()
+	if err != nil {
+		return err
+	}
+	if foundRestore == nil {
+		t.Restore = newRestore
+		client, err := t.getDestinationClient()
+		if err != nil {
+			return err
+		}
+		err = client.Create(context.TODO(), newRestore)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	t.Restore = foundRestore
+	if !t.equalsRestore(newRestore, foundRestore) {
+		t.updateRestore(foundRestore)
+		client, err := t.getDestinationClient()
+		if err != nil {
+			return err
+		}
+		err = client.Update(context.TODO(), foundRestore)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Get whether the two Restores are equal.
+func (t *Task) equalsRestore(a, b *velero.Restore) bool {
+	match := a.Spec.BackupName == b.Spec.BackupName &&
+		*a.Spec.RestorePVs == *b.Spec.RestorePVs
+	return match
+}
+
+// Get an existing Restore on the destination cluster.
+func (t Task) getRestore() (*velero.Restore, error) {
+	client, err := t.getDestinationClient()
+	if err != nil {
+		return nil, err
+	}
+	list := velero.RestoreList{}
+	labels := t.Owner.GetCorrelationLabels()
+	err = client.List(
+		context.TODO(),
+		k8sclient.MatchingLabels(labels),
+		&list)
+	if err != nil {
+		return nil, err
+	}
+	if len(list.Items) > 0 {
+		return &list.Items[0], nil
+	}
+
+	return nil, nil
+}
+
+// Build a Restore as desired for the destination cluster.
+func (t *Task) buildRestore() *velero.Restore {
+	restore := &velero.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:       t.Owner.GetCorrelationLabels(),
+			GenerateName: t.Owner.GetName() + "-",
+			Namespace:    VeleroNamespace,
+		},
+	}
+	t.updateRestore(restore)
+	return restore
+}
+
+// Update a Restore as desired for the destination cluster.
+func (t *Task) updateRestore(restore *velero.Restore) {
+	restorePVs := true
+	restore.Spec = velero.RestoreSpec{
+		BackupName: t.Backup.Name,
+		RestorePVs: &restorePVs,
+	}
+}
+
+// Get a Backup that has been replicated by velero on the destination cluster.
+func (t *Task) getReplicatedBackup() (*velero.Backup, error) {
+	client, err := t.getDestinationClient()
+	if err != nil {
+		return nil, err
+	}
+	list := velero.BackupList{}
+	labels := t.Owner.GetCorrelationLabels()
+	err = client.List(
+		context.TODO(),
+		k8sclient.MatchingLabels(labels),
+		&list)
+	if err != nil {
+		return nil, err
+	}
+	if len(list.Items) > 0 {
+		return &list.Items[0], nil
+	}
+
+	return nil, nil
+}
+
+// Get a client for the source cluster using the cache.
+func (t *Task) getSourceClient() (k8sclient.Client, error) {
+	return t.getClient(t.PlanResources.SrcMigCluster)
+}
+
+// Get a client for the destination cluster using the cache.
+func (t *Task) getDestinationClient() (k8sclient.Client, error) {
+	return t.getClient(t.PlanResources.DestMigCluster)
+}
+
+// Get a client for the cluster using the cache.
+func (t *Task) getClient(cluster *migapi.MigCluster) (k8sclient.Client, error) {
+	if t.ClientCache == nil {
+		t.ClientCache = map[*migapi.MigCluster]k8sclient.Client{}
+	}
+	client, found := t.ClientCache[cluster]
+	if found {
+		return client, nil
+	}
+	client, err := cluster.GetClient(t.Client)
+	if err != nil {
+		return nil, err
+	} else {
+		t.ClientCache[cluster] = client
+	}
+
+	return client, nil
+}


### PR DESCRIPTION
Refactor `velerorunner` package to include a velero `Task` for doing backup/restore workflows with _context_.  This approach more easily supports using correlation labels and setting the BSL/VSL properly. 

Updated the migration controller to leverage the `Task`.  The `migration.go` is a good place to start.

In support:
- Added `MigResource` _interface_ in `resource.go`.  This provides an interface for all of our CRs and is useful for the shared code.  The _velerorunner_ package shared by the migration & stage controllers.
- Separated _labels_ into separete `labels.go` file.
- Added MigStorage to `PlanRefResources`.
- The _velerorunner_ package defines a `VeleroNamespace` global.

In Addition:
- Checking for _Conflict_ errors _"object has been modified; please apply your changes to the latest version and try again" by quietly requeuing to reduce the noise in the log.
- Named each controller logger after the controller problem domain per the long term logging plan.  This deprecates the need for _logPrefix_.

Questions:
- Do we really want every `Reconcile()` logged?  I don't think it's useful any longer.