### PR TITLE
Validate asset-collection namespaces on the source cluster.

### DIFF
--- a/pkg/controller/migassetcollection/validation.go
+++ b/pkg/controller/migassetcollection/validation.go
@@ -2,18 +2,12 @@ package migassetcollection
 
 import (
 	"context"
-	"fmt"
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
-	kapi "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"strings"
 )
 
 // Types
 const (
-	EmptyCollection    = "EmptyCollection"
-	NamespacesNotFound = "NamespacesNotFound"
+	EmptyCollection = "EmptyCollection"
 )
 
 // Reasons
@@ -29,9 +23,8 @@ const (
 
 // Messages
 const (
-	ReadyMessage             = "The asset-collection is ready."
-	NamespaceNotFoundMessage = "The following `namespaces` [%s] not found on the source cluster."
-	EmptyCollectionMessage   = "The `namespaces` list may not be empty."
+	ReadyMessage           = "The asset-collection is ready."
+	EmptyCollectionMessage = "The `namespaces` list may not be empty."
 )
 
 // Validate the asset collection resource.
@@ -41,13 +34,6 @@ func (r ReconcileMigAssetCollection) validate(assetCollection *migapi.MigAssetCo
 
 	// Empty collection
 	nSet, err := r.validateEmpty(assetCollection)
-	if err != nil {
-		return 0, err
-	}
-	totalSet += nSet
-
-	// Validate listed assets
-	nSet, err = r.validateAssets(assetCollection)
 	if err != nil {
 		return 0, err
 	}
@@ -72,36 +58,6 @@ func (r ReconcileMigAssetCollection) validateEmpty(assetCollection *migapi.MigAs
 			Type:    EmptyCollection,
 			Status:  True,
 			Message: EmptyCollectionMessage,
-		})
-		return 1, nil
-	}
-
-	return 0, nil
-}
-
-func (r ReconcileMigAssetCollection) validateAssets(assetCollection *migapi.MigAssetCollection) (int, error) {
-	notFound := make([]string, 0)
-	ns := kapi.Namespace{}
-	for _, name := range assetCollection.Spec.Namespaces {
-		key := types.NamespacedName{Name: name}
-		err := r.Get(context.TODO(), key, &ns) // TODO: query source cluster instead.
-		if err == nil {
-			continue
-		}
-		if errors.IsNotFound(err) {
-			notFound = append(notFound, name)
-		} else {
-			return 0, err
-		}
-	}
-
-	if len(notFound) > 0 {
-		message := fmt.Sprintf(NamespaceNotFoundMessage, strings.Join(notFound, ", "))
-		assetCollection.Status.SetCondition(migapi.Condition{
-			Type:    NamespacesNotFound,
-			Status:  True,
-			Reason:  NotFound,
-			Message: message,
 		})
 		return 1, nil
 	}

--- a/pkg/controller/migassetcollection/validation.go
+++ b/pkg/controller/migassetcollection/validation.go
@@ -57,6 +57,7 @@ func (r ReconcileMigAssetCollection) validate(assetCollection *migapi.MigAssetCo
 	assetCollection.Status.SetReady(totalSet == 0, ReadyMessage)
 
 	// Apply changes
+	assetCollection.Status.CommitConditions()
 	err = r.Update(context.TODO(), assetCollection)
 	if err != nil {
 		return 0, err
@@ -73,8 +74,6 @@ func (r ReconcileMigAssetCollection) validateEmpty(assetCollection *migapi.MigAs
 			Message: EmptyCollectionMessage,
 		})
 		return 1, nil
-	} else {
-		assetCollection.Status.DeleteCondition(EmptyCollection)
 	}
 
 	return 0, nil
@@ -105,8 +104,6 @@ func (r ReconcileMigAssetCollection) validateAssets(assetCollection *migapi.MigA
 			Message: message,
 		})
 		return 1, nil
-	} else {
-		assetCollection.Status.DeleteCondition(NamespacesNotFound)
 	}
 
 	return 0, nil

--- a/pkg/controller/migcluster/validation.go
+++ b/pkg/controller/migcluster/validation.go
@@ -73,6 +73,7 @@ func (r ReconcileMigCluster) validate(cluster *migapi.MigCluster) (int, error) {
 	cluster.Status.SetReady(totalSet == 0, ReadyMessage)
 
 	// Apply changes.
+	cluster.Status.CommitConditions()
 	err = r.Update(context.TODO(), cluster)
 	if err != nil {
 		return 0, err
@@ -86,7 +87,6 @@ func (r ReconcileMigCluster) validateRegistryCluster(cluster *migapi.MigCluster)
 
 	// Not needed.
 	if cluster.Spec.IsHostCluster {
-		cluster.Status.DeleteCondition(InvalidClusterRef)
 		return 0, nil
 	}
 
@@ -115,8 +115,6 @@ func (r ReconcileMigCluster) validateRegistryCluster(cluster *migapi.MigCluster)
 			Message: InvalidClusterRefMessage,
 		})
 		return 1, nil
-	} else {
-		cluster.Status.DeleteCondition(InvalidClusterRef)
 	}
 
 	return 0, nil
@@ -150,8 +148,6 @@ func (r ReconcileMigCluster) validateSaSecret(cluster *migapi.MigCluster) (int, 
 
 	// Not needed.
 	if cluster.Spec.IsHostCluster {
-		cluster.Status.DeleteCondition(InvalidSaSecretRef)
-		cluster.Status.DeleteCondition(InvalidSaToken)
 		return 0, nil
 	}
 
@@ -163,7 +159,6 @@ func (r ReconcileMigCluster) validateSaSecret(cluster *migapi.MigCluster) (int, 
 			Reason:  NotSet,
 			Message: InvalidSaSecretRefMessage,
 		})
-		cluster.Status.DeleteCondition(InvalidSaToken)
 		return 1, nil
 	}
 
@@ -180,10 +175,7 @@ func (r ReconcileMigCluster) validateSaSecret(cluster *migapi.MigCluster) (int, 
 			Reason:  NotFound,
 			Message: InvalidSaSecretRefMessage,
 		})
-		cluster.Status.DeleteCondition(InvalidSaToken)
 		return 1, nil
-	} else {
-		cluster.Status.DeleteCondition(InvalidSaSecretRef)
 	}
 
 	// saToken
@@ -205,8 +197,6 @@ func (r ReconcileMigCluster) validateSaSecret(cluster *migapi.MigCluster) (int, 
 			Message: InvalidSaTokenMessage,
 		})
 		return 1, nil
-	} else {
-		cluster.Status.DeleteCondition(InvalidSaToken)
 	}
 
 	return 0, nil
@@ -215,7 +205,6 @@ func (r ReconcileMigCluster) validateSaSecret(cluster *migapi.MigCluster) (int, 
 // Test the connection.
 func (r ReconcileMigCluster) testConnection(cluster *migapi.MigCluster, totalSet int) (int, error) {
 	if cluster.Spec.IsHostCluster {
-		cluster.Status.DeleteCondition(TestConnectFailed)
 		return 0, nil
 	}
 	if totalSet > 0 {
@@ -231,8 +220,6 @@ func (r ReconcileMigCluster) testConnection(cluster *migapi.MigCluster, totalSet
 			Message: message,
 		})
 		return 1, nil
-	} else {
-		cluster.Status.DeleteCondition(TestConnectFailed)
 	}
 
 	return 0, nil

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -50,6 +50,7 @@ func (r ReconcileMigMigration) validate(migration *migapi.MigMigration) (int, er
 	migration.Status.SetReady(totalSet == 0, ReadyMessage)
 
 	// Apply changes.
+	migration.Status.CommitConditions()
 	err = r.Update(context.TODO(), migration)
 	if err != nil {
 		return 0, err
@@ -71,7 +72,6 @@ func (r ReconcileMigMigration) validatePlan(migration *migapi.MigMigration) (int
 			Reason:  NotSet,
 			Message: InvalidPlanRefMessage,
 		})
-		migration.Status.DeleteCondition(PlanNotReady)
 		return 1, nil
 	}
 
@@ -88,10 +88,7 @@ func (r ReconcileMigMigration) validatePlan(migration *migapi.MigMigration) (int
 			Reason:  NotFound,
 			Message: InvalidPlanRefMessage,
 		})
-		migration.Status.DeleteCondition(PlanNotReady)
 		return 1, nil
-	} else {
-		migration.Status.DeleteCondition(InvalidPlanRef)
 	}
 
 	// NotReady
@@ -102,8 +99,6 @@ func (r ReconcileMigMigration) validatePlan(migration *migapi.MigMigration) (int
 			Message: PlanNotReadyMessage,
 		})
 		return 1, nil
-	} else {
-		migration.Status.DeleteCondition(PlanNotReady)
 	}
 
 	return 0, nil

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -86,6 +86,7 @@ func (r ReconcileMigPlan) validate(plan *migapi.MigPlan) (int, error) {
 	totalSet += nSet
 
 	// Apply changes.
+	plan.Status.CommitConditions()
 	err = r.Update(context.TODO(), plan)
 	if err != nil {
 		return 0, err
@@ -107,7 +108,6 @@ func (r ReconcileMigPlan) validateStorage(plan *migapi.MigPlan) (int, error) {
 			Reason:  NotSet,
 			Message: InvalidStorageRefMessage,
 		})
-		plan.Status.DeleteCondition(StorageNotReady)
 		return 1, nil
 	}
 
@@ -124,10 +124,7 @@ func (r ReconcileMigPlan) validateStorage(plan *migapi.MigPlan) (int, error) {
 			Reason:  NotFound,
 			Message: InvalidStorageRefMessage,
 		})
-		plan.Status.DeleteCondition(StorageNotReady)
 		return 1, nil
-	} else {
-		plan.Status.DeleteCondition(InvalidStorageRef)
 	}
 
 	// NotReady
@@ -138,8 +135,6 @@ func (r ReconcileMigPlan) validateStorage(plan *migapi.MigPlan) (int, error) {
 			Message: StorageNotReadyMessage,
 		})
 		return 1, nil
-	} else {
-		plan.Status.DeleteCondition(StorageNotReady)
 	}
 
 	return 0, nil
@@ -158,7 +153,6 @@ func (r ReconcileMigPlan) validateAssetCollection(plan *migapi.MigPlan) (int, er
 			Reason:  NotSet,
 			Message: InvalidAssetCollectionRefMessage,
 		})
-		plan.Status.DeleteCondition(AssetCollectionNotReady)
 		return 1, nil
 	}
 
@@ -175,10 +169,7 @@ func (r ReconcileMigPlan) validateAssetCollection(plan *migapi.MigPlan) (int, er
 			Reason:  NotFound,
 			Message: InvalidAssetCollectionRefMessage,
 		})
-		plan.Status.DeleteCondition(AssetCollectionNotReady)
 		return 1, nil
-	} else {
-		plan.Status.DeleteCondition(InvalidAssetCollectionRef)
 	}
 
 	// NotReady
@@ -189,8 +180,6 @@ func (r ReconcileMigPlan) validateAssetCollection(plan *migapi.MigPlan) (int, er
 			Message: AssetCollectionNotReadyMessage,
 		})
 		return 1, nil
-	} else {
-		plan.Status.DeleteCondition(AssetCollectionNotReady)
 	}
 
 	return 0, nil
@@ -209,7 +198,6 @@ func (r ReconcileMigPlan) validateSourceCluster(plan *migapi.MigPlan) (int, erro
 			Reason:  NotSet,
 			Message: InvalidSourceClusterRefMessage,
 		})
-		plan.Status.DeleteCondition(SourceClusterNotReady)
 		return 1, nil
 	}
 
@@ -226,10 +214,7 @@ func (r ReconcileMigPlan) validateSourceCluster(plan *migapi.MigPlan) (int, erro
 			Reason:  NotFound,
 			Message: InvalidSourceClusterRefMessage,
 		})
-		plan.Status.DeleteCondition(SourceClusterNotReady)
 		return 1, nil
-	} else {
-		plan.Status.DeleteCondition(InvalidSourceClusterRef)
 	}
 
 	// NotReady
@@ -240,8 +225,6 @@ func (r ReconcileMigPlan) validateSourceCluster(plan *migapi.MigPlan) (int, erro
 			Message: SourceClusterNotReadyMessage,
 		})
 		return 1, nil
-	} else {
-		plan.Status.DeleteCondition(SourceClusterNotReady)
 	}
 
 	return 0, nil
@@ -260,8 +243,6 @@ func (r ReconcileMigPlan) validateDestinationCluster(plan *migapi.MigPlan) (int,
 			Reason:  NotSet,
 			Message: InvalidDestinationClusterRefMessage,
 		})
-		plan.Status.DeleteCondition(InvalidDestinationCluster)
-		plan.Status.DeleteCondition(DestinationClusterNotReady)
 		return 1, nil
 	}
 
@@ -273,10 +254,7 @@ func (r ReconcileMigPlan) validateDestinationCluster(plan *migapi.MigPlan) (int,
 			Reason:  NotDistinct,
 			Message: InvalidDestinationClusterMessage,
 		})
-		plan.Status.DeleteCondition(DestinationClusterNotReady)
 		return 1, nil
-	} else {
-		plan.Status.DeleteCondition(InvalidDestinationCluster)
 	}
 
 	cluster, err := migapi.GetCluster(r, ref)
@@ -292,10 +270,7 @@ func (r ReconcileMigPlan) validateDestinationCluster(plan *migapi.MigPlan) (int,
 			Reason:  NotFound,
 			Message: InvalidDestinationClusterRefMessage,
 		})
-		plan.Status.DeleteCondition(DestinationClusterNotReady)
 		return 1, nil
-	} else {
-		plan.Status.DeleteCondition(InvalidDestinationClusterRef)
 	}
 
 	// NotReady
@@ -306,8 +281,6 @@ func (r ReconcileMigPlan) validateDestinationCluster(plan *migapi.MigPlan) (int,
 			Message: DestinationClusterNotReadyMessage,
 		})
 		return 1, nil
-	} else {
-		plan.Status.DeleteCondition(DestinationClusterNotReady)
 	}
 
 	return 0, nil

--- a/pkg/controller/migstage/validation.go
+++ b/pkg/controller/migstage/validation.go
@@ -34,23 +34,24 @@ const (
 
 // Validate the plan resource.
 // Returns error and the total error conditions set.
-func (r ReconcileMigStage) validate(migration *migapi.MigStage) (int, error) {
+func (r ReconcileMigStage) validate(stage *migapi.MigStage) (int, error) {
 	totalSet := 0
 	var err error
 	nSet := 0
 
 	// Plan
-	nSet, err = r.validatePlan(migration)
+	nSet, err = r.validatePlan(stage)
 	if err != nil {
 		return 0, err
 	}
 	totalSet += nSet
 
 	// Ready
-	migration.Status.SetReady(totalSet == 0, ReadyMessage)
+	stage.Status.SetReady(totalSet == 0, ReadyMessage)
 
 	// Apply changes.
-	err = r.Update(context.TODO(), migration)
+	stage.Status.CommitConditions()
+	err = r.Update(context.TODO(), stage)
 	if err != nil {
 		return 0, err
 	}
@@ -60,18 +61,17 @@ func (r ReconcileMigStage) validate(migration *migapi.MigStage) (int, error) {
 
 // Validate the referenced plan.
 // Returns error and the total error conditions set.
-func (r ReconcileMigStage) validatePlan(migration *migapi.MigStage) (int, error) {
-	ref := migration.Spec.MigPlanRef
+func (r ReconcileMigStage) validatePlan(stage *migapi.MigStage) (int, error) {
+	ref := stage.Spec.MigPlanRef
 
 	// NotSet
 	if !migref.RefSet(ref) {
-		migration.Status.SetCondition(migapi.Condition{
+		stage.Status.SetCondition(migapi.Condition{
 			Type:    InvalidPlanRef,
 			Status:  True,
 			Reason:  NotSet,
 			Message: InvalidPlanRefMessage,
 		})
-		migration.Status.DeleteCondition(PlanNotReady)
 		return 1, nil
 	}
 
@@ -82,28 +82,23 @@ func (r ReconcileMigStage) validatePlan(migration *migapi.MigStage) (int, error)
 
 	// NotFound
 	if plan == nil {
-		migration.Status.SetCondition(migapi.Condition{
+		stage.Status.SetCondition(migapi.Condition{
 			Type:    InvalidPlanRef,
 			Status:  True,
 			Reason:  NotFound,
 			Message: InvalidPlanRefMessage,
 		})
-		migration.Status.DeleteCondition(PlanNotReady)
 		return 1, nil
-	} else {
-		migration.Status.DeleteCondition(InvalidPlanRef)
 	}
 
 	// NotReady
 	if !plan.Status.IsReady() {
-		migration.Status.SetCondition(migapi.Condition{
+		stage.Status.SetCondition(migapi.Condition{
 			Type:    PlanNotReady,
 			Status:  True,
 			Message: PlanNotReadyMessage,
 		})
 		return 1, nil
-	} else {
-		migration.Status.DeleteCondition(PlanNotReady)
 	}
 
 	return 0, nil

--- a/pkg/controller/migstorage/validation.go
+++ b/pkg/controller/migstorage/validation.go
@@ -75,6 +75,7 @@ func (r ReconcileMigStorage) validate(storage *migapi.MigStorage) (int, error) {
 	storage.Status.SetReady(totalSet == 0, ReadyMessage)
 
 	// Apply changes.
+	storage.Status.CommitConditions()
 	err = r.Update(context.TODO(), storage)
 	if err != nil {
 		return 0, err
@@ -106,11 +107,7 @@ func (r ReconcileMigStorage) validateBSL(storage *migapi.MigStorage) (int, error
 		})
 		return 1, nil
 	}
-
 	totalSet += nSet
-	if err == nil && nSet == 0 {
-		storage.Status.DeleteCondition(InvalidBSLProvider)
-	}
 
 	nSet, err = r.validateBSLCredsSecret(storage)
 	if err != nil {
@@ -187,8 +184,6 @@ func (r ReconcileMigStorage) validateAzureBSLSettings(storage *migapi.MigStorage
 
 func (r ReconcileMigStorage) validateBSLCredsSecret(storage *migapi.MigStorage) (int, error) {
 	if storage.Spec.BackupStorageProvider == "" {
-		storage.Status.DeleteCondition(InvalidBSLCredsSecretRef)
-		storage.Status.DeleteCondition(InvalidBSLCredsSecret)
 		return 0, nil
 	}
 
@@ -202,7 +197,6 @@ func (r ReconcileMigStorage) validateBSLCredsSecret(storage *migapi.MigStorage) 
 			Reason:  NotSet,
 			Message: InvalidBSLCredsSecretRefMessage,
 		})
-		storage.Status.DeleteCondition(InvalidBSLCredsSecret)
 		return 1, nil
 	}
 
@@ -219,10 +213,7 @@ func (r ReconcileMigStorage) validateBSLCredsSecret(storage *migapi.MigStorage) 
 			Reason:  NotFound,
 			Message: InvalidBSLCredsSecretRefMessage,
 		})
-		storage.Status.DeleteCondition(InvalidBSLCredsSecret)
 		return 1, nil
-	} else {
-		storage.Status.DeleteCondition(InvalidBSLCredsSecretRef)
 	}
 
 	// secret content
@@ -234,8 +225,6 @@ func (r ReconcileMigStorage) validateBSLCredsSecret(storage *migapi.MigStorage) 
 			Message: InvalidBSLCredsSecretMessage,
 		})
 		return 1, nil
-	} else {
-		storage.Status.DeleteCondition(InvalidBSLCredsSecret)
 	}
 
 	return 0, nil
@@ -264,11 +253,7 @@ func (r ReconcileMigStorage) validateVSL(storage *migapi.MigStorage) (int, error
 		})
 		return 1, nil
 	}
-
 	totalSet += nSet
-	if err == nil && nSet == 0 {
-		storage.Status.DeleteCondition(InvalidVSLProvider)
-	}
 
 	nSet, err = r.validateVSLCredsSecret(storage)
 	if err != nil {
@@ -332,8 +317,6 @@ func (r ReconcileMigStorage) validateAzureVSLSettings(storage *migapi.MigStorage
 
 func (r ReconcileMigStorage) validateVSLCredsSecret(storage *migapi.MigStorage) (int, error) {
 	if storage.Spec.VolumeSnapshotProvider == "" {
-		storage.Status.DeleteCondition(InvalidVSLCredsSecretRef)
-		storage.Status.DeleteCondition(InvalidVSLCredsSecret)
 		return 0, nil
 	}
 
@@ -347,7 +330,6 @@ func (r ReconcileMigStorage) validateVSLCredsSecret(storage *migapi.MigStorage) 
 			Reason:  NotSet,
 			Message: InvalidVSLCredsSecretRefMessage,
 		})
-		storage.Status.DeleteCondition(InvalidVSLCredsSecret)
 		return 1, nil
 	}
 
@@ -364,10 +346,7 @@ func (r ReconcileMigStorage) validateVSLCredsSecret(storage *migapi.MigStorage) 
 			Reason:  NotFound,
 			Message: InvalidVSLCredsSecretRefMessage,
 		})
-		storage.Status.DeleteCondition(InvalidVSLCredsSecret)
 		return 1, nil
-	} else {
-		storage.Status.DeleteCondition(InvalidVSLCredsSecretRef)
 	}
 
 	// secret content
@@ -379,8 +358,6 @@ func (r ReconcileMigStorage) validateVSLCredsSecret(storage *migapi.MigStorage) 
 			Message: InvalidVSLCredsSecretMessage,
 		})
 		return 1, nil
-	} else {
-		storage.Status.DeleteCondition(InvalidVSLCredsSecret)
 	}
 
 	return 0, nil


### PR DESCRIPTION
Validate asset-collection namespaces on the source cluster.  Since an AssetCollection is shared between plans, it's more appropriate for the plan to perform the validation.

Depends on: https://github.com/fusor/mig-controller/pull/57 which needs to be merged first.  There should only be 2 affected files.