### PR TITLE
Fix SEGV in plan storage ensureStorage().

### DIFF
--- a/pkg/controller/migplan/storage.go
+++ b/pkg/controller/migplan/storage.go
@@ -30,6 +30,9 @@ func (r ReconcileMigPlan) ensureStorage(plan *migapi.MigPlan) (bool, error) {
 			continue
 		}
 		client, err = cluster.GetClient(r)
+		if err != nil {
+			return false, err
+		}
 		// BSL
 		ensured, err := r.ensureBSL(client, storage)
 		if err != nil {


### PR DESCRIPTION
Fix SEGV.

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0xf7c3d8]

goroutine 295 [running]:
github.com/fusor/mig-controller/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/home/jortel/go/src/github.com/fusor/mig-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x108
panic(0x11e89c0, 0x2007fe0)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1.(*MigStorage).GetBSL(0xc002f34240, 0x0, 0x0, 0xc00699ce00, 0x0, 0x0)
	/home/jortel/go/src/github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1/migstorage_types.go:184 +0x68
github.com/fusor/mig-controller/pkg/controller/migplan.ReconcileMigPlan.ensureBSL(0x14d2b20, 0xc0005a6660, 0xc000229180, 0x0, 0x0, 0xc002f34240, 0xc007009890, 0x0, 0x0)
	/home/jortel/go/src/github.com/fusor/mig-controller/pkg/controller/migplan/storage.go:82 +0x61
github.com/fusor/mig-controller/pkg/controller/migplan.ReconcileMigPlan.ensureStorage(0x14d2b20, 0xc0005a6660, 0xc000229180, 0xc00155a500, 0x0, 0x0, 0x0)
	/home/jortel/go/src/github.com/fusor/mig-controller/pkg/controller/migplan/storage.go:34 +0x440
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0xf7c3d8]

goroutine 295 [running]:
github.com/fusor/mig-controller/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/home/jortel/go/src/github.com/fusor/mig-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x108
panic(0x11e89c0, 0x2007fe0)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1.(*MigStorage).GetBSL(0xc002f34240, 0x0, 0x0, 0xc00699ce00, 0x0, 0x0)
	/home/jortel/go/src/github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1/migstorage_types.go:184 +0x68
github.com/fusor/mig-controller/pkg/controller/migplan.ReconcileMigPlan.ensureBSL(0x14d2b20, 0xc0005a6660, 0xc000229180, 0x0, 0x0, 0xc002f34240, 0xc007009890, 0x0, 0x0)
	/home/jortel/go/src/github.com/fusor/mig-controller/pkg/controller/migplan/storage.go:82 +0x61
github.com/fusor/mig-controller/pkg/controller/migplan.ReconcileMigPlan.ensureStorage(0x14d2b20, 0xc0005a6660, 0xc000229180, 0xc00155a500, 0x0, 0x0, 0x0)
	/home/jortel/go/src/github.com/fusor/mig-controller/pkg/controller/migplan/storage.go:34 +0x440
```