### PR TITLE
Improved logging.

### DIFF
--- a/pkg/controller/migassetcollection/migassetcollection_controller.go
+++ b/pkg/controller/migassetcollection/migassetcollection_controller.go
@@ -18,6 +18,7 @@ package migassetcollection
 
 import (
 	"context"
+	"k8s.io/apiserver/pkg/storage/names"
 
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
@@ -99,6 +100,8 @@ type ReconcileMigAssetCollection struct {
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migassetcollections,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migassetcollections/status,verbs=get;update;patch
 func (r *ReconcileMigAssetCollection) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log = logf.Log.WithName(names.SimpleNameGenerator.GenerateName("asset-collection|"))
+
 	// Fetch the MigAssetCollection instance
 	assetCollection := &migapi.MigAssetCollection{}
 	err := r.Get(context.TODO(), request.NamespacedName, assetCollection)

--- a/pkg/controller/migcluster/migcluster_controller.go
+++ b/pkg/controller/migcluster/migcluster_controller.go
@@ -18,7 +18,7 @@ package migcluster
 
 import (
 	"context"
-	"fmt"
+	"k8s.io/apiserver/pkg/storage/names"
 
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
@@ -116,7 +116,7 @@ type ReconcileMigCluster struct {
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migclusters/status,verbs=get;update;patch
 func (r *ReconcileMigCluster) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.Info("Reconcile", "request", request.Name)
+	log = logf.Log.WithName(names.SimpleNameGenerator.GenerateName("cluster|"))
 
 	// Fetch the MigCluster
 	migCluster := &migapi.MigCluster{}
@@ -146,20 +146,17 @@ func (r *ReconcileMigCluster) Reconcile(request reconcile.Request) (reconcile.Re
 	remoteWatchCluster := remoteWatchMap.Get(request.NamespacedName)
 
 	if remoteWatchCluster == nil {
-		log.Info(fmt.Sprintf("[mCluster] Starting RemoteWatch for MigCluster [%s/%s]", request.Namespace, request.Name))
+		log.Info("Starting remote watch.", "cluster", request.Name)
 
 		var restCfg *rest.Config
-
 		if migCluster.Spec.IsHostCluster {
 			restCfg, err = config.GetConfig()
 			if err != nil {
-				log.Error(err, fmt.Sprintf("[mCluster] Error during config.GetConfig() for RemoteWatch on MigCluster [%s/%s]", request.Namespace, request.Name))
 				return reconcile.Result{}, err
 			}
 		} else {
 			restCfg, err = migCluster.BuildRestConfig(r.Client)
 			if err != nil {
-				log.Error(err, fmt.Sprintf("[mCluster] Error during BuildRestConfig() for RemoteWatch on MigCluster [%s/%s]", request.Namespace, request.Name))
 				return reconcile.Result{}, nil // don't requeue
 			}
 		}
@@ -169,7 +166,8 @@ func (r *ReconcileMigCluster) Reconcile(request reconcile.Request) (reconcile.Re
 			ParentNsName:     request.NamespacedName,
 			ParentResource:   migCluster,
 		})
-		log.Info(fmt.Sprintf("[mCluster] RemoteWatch started successfully for MigCluster [%s/%s]", request.Namespace, request.Name))
+
+		log.Info("Remote watch started.", "cluster", request.Name)
 	}
 
 	// Done

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
+	"k8s.io/apiserver/pkg/storage/names"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -94,7 +95,7 @@ type ReconcileMigMigration struct {
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migmigrations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migmigrations/status,verbs=get;update;patch
 func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.Info("Reconcile", "request", request)
+	log = logf.Log.WithName(names.SimpleNameGenerator.GenerateName("migration|"))
 
 	// Retrieve the MigMigration being reconciled
 	migration := &migapi.MigMigration{}

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -18,6 +18,7 @@ package migplan
 
 import (
 	"context"
+	"k8s.io/apiserver/pkg/storage/names"
 
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
@@ -119,6 +120,8 @@ type ReconcileMigPlan struct {
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migplans,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migplans/status,verbs=get;update;patch
 func (r *ReconcileMigPlan) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log = logf.Log.WithName(names.SimpleNameGenerator.GenerateName("plan|"))
+
 	// Fetch the MigPlan instance
 	plan := &migapi.MigPlan{}
 	err := r.Get(context.TODO(), request.NamespacedName, plan)

--- a/pkg/controller/migstage/migstage_controller.go
+++ b/pkg/controller/migstage/migstage_controller.go
@@ -22,6 +22,7 @@ import (
 	migref "github.com/fusor/mig-controller/pkg/reference"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/storage/names"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -113,7 +114,7 @@ type ReconcileMigStage struct {
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migstages,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migstages/status,verbs=get;update;patch
 func (r *ReconcileMigStage) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.Info("Reconcile", "request", request)
+	log = logf.Log.WithName(names.SimpleNameGenerator.GenerateName("stage|"))
 
 	// Fetch the MigStage instance
 	migStage := &migapi.MigStage{}

--- a/pkg/controller/migstorage/migstorage_controller.go
+++ b/pkg/controller/migstorage/migstorage_controller.go
@@ -23,6 +23,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/storage/names"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -97,7 +98,7 @@ type ReconcileMigStorage struct {
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migstorages,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=migration.openshift.io,resources=migstorages/status,verbs=get;update;patch
 func (r *ReconcileMigStorage) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.Info("Reconcile", "request", request)
+	log = logf.Log.WithName(names.SimpleNameGenerator.GenerateName("storage|"))
 
 	// Fetch the MigStorage instance
 	storage := &migapi.MigStorage{}

--- a/pkg/controller/remotewatcher/remotewatcher_controller.go
+++ b/pkg/controller/remotewatcher/remotewatcher_controller.go
@@ -14,7 +14,6 @@ limitations under the License.
 package remotewatcher
 
 import (
-	"fmt"
 	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -83,11 +82,7 @@ type ReconcileRemoteWatcher struct {
 
 // Reconcile reads that state of the cluster for a RemoteWatcher object and makes changes
 func (r *ReconcileRemoteWatcher) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.Info(fmt.Sprintf("Forward reconcile to MigCluster: [%s/%s] <= [%s/%s]",
-		r.ForwardEvent.Meta.GetNamespace(), r.ForwardEvent.Meta.GetName(), request.Namespace, request.Name))
-
 	// Forward a known Event back to the parent controller
 	r.ForwardChannel <- r.ForwardEvent
-
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
Use the logger name to correlate messages logged within a reconcile.

Example:
```
{"level":"info","ts":1557442000.3781226,"logger":"cluster|p8w44","msg":"[rWatch] Starting manager"}
{"level":"info","ts":1557442000.378142,"logger":"cluster|p8w44","msg":"[rWatch] Manager started"}
{"level":"info","ts":1557442000.3781505,"logger":"cluster|p8w44","msg":"Remote watch started.","cluster":"ocp4"}
```