### PR TITLE
Bounce restic pod prior to running Velero backup

### DIFF
--- a/config/crds/migration_v1alpha1_migmigration.yaml
+++ b/config/crds/migration_v1alpha1_migmigration.yaml
@@ -36,16 +36,14 @@ spec:
             completionTimestamp:
               format: date-time
               type: string
-            destRestoreRef:
-              type: object
             migrationCompleted:
               type: boolean
             migrationStarted:
               type: boolean
-            srcBackupRef:
-              type: object
             startTimestamp:
               format: date-time
+              type: string
+            taskPhase:
               type: string
           type: object
   version: v1alpha1

--- a/config/crds/migration_v1alpha1_migstage.yaml
+++ b/config/crds/migration_v1alpha1_migstage.yaml
@@ -36,16 +36,14 @@ spec:
             completionTimestamp:
               format: date-time
               type: string
-            destRestoreRef:
-              type: object
-            srcBackupRef:
-              type: object
             stageCompleted:
               type: boolean
             stageStarted:
               type: boolean
             startTimestamp:
               format: date-time
+              type: string
+            taskPhase:
               type: string
           type: object
   version: v1alpha1

--- a/config/crds/migration_v1alpha1_migstorage.yaml
+++ b/config/crds/migration_v1alpha1_migstorage.yaml
@@ -40,6 +40,8 @@ spec:
                   type: string
                 awsS3ForcePathStyle:
                   type: boolean
+                awsS3Url:
+                  type: string
                 awsSignatureVersion:
                   type: string
                 azureResourceGroup:

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -18,6 +18,7 @@ package migmigration
 
 import (
 	"context"
+
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	vrunner "github.com/fusor/mig-controller/pkg/velerorunner"
 )

--- a/pkg/controller/migstage/stage.go
+++ b/pkg/controller/migstage/stage.go
@@ -18,6 +18,7 @@ package migstage
 
 import (
 	"context"
+
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	vrunner "github.com/fusor/mig-controller/pkg/velerorunner"
 )


### PR DESCRIPTION
This is a workaround to solve the issue where 3.7-3.9 does not support the mount propagation feature needed for restic. To get around this, we bounce the pod prior to creating a backup.