### PR TITLE
Release script

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ "$0" != "hack/release.sh" ]; then echo "Usage: run 'hack/release.sh' from project base directory"; exit 1; fi
+if [ -z "$1" ]; then echo "Usage: 'hack/release.sh RELEASE_TAG_TO_CREATE'"; exit 2; fi
+
+mig_release_tag=$1
+
+mkdir -p config/releases
+kustomize build config/default > config/releases/$mig_release_tag.yaml
+echo "Wrote release manifest 'config/releases/$mig_release_tag.yaml'"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,10 +1,43 @@
 #!/bin/bash
 
 if [ "$0" != "hack/release.sh" ]; then echo "Usage: run 'hack/release.sh' from project base directory"; exit 1; fi
-if [ -z "$1" ]; then echo "Usage: 'hack/release.sh RELEASE_TAG_TO_CREATE'"; exit 2; fi
+if [ -z "$1" ]; then echo "Usage: 'hack/release.sh RELEASE_SEMVER'"; exit 2; fi
 
 mig_release_tag=$1
 
-mkdir -p config/releases
-kustomize build config/default > config/releases/$mig_release_tag.yaml
-echo "Wrote release manifest 'config/releases/$mig_release_tag.yaml'"
+echo "Patching release image before 'kustomize build config/default'"
+cat <<EOF > config/default/manager_image_patch.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: controller-manager
+  namespace: mig
+spec:
+  template:
+    spec:
+      containers:
+      # Change the value of image field below to your controller image URL
+      - image: quay.io/ocpmigrate/mig-controller:$mig_release_tag
+        name: manager
+EOF
+
+echo "Writing release manifest to 'config/releases/$mig_release_tag/manifest.yaml'"
+mkdir -p config/releases/$mig_release_tag
+kustomize build config/default > config/releases/$mig_release_tag/manifest.yaml
+
+echo "Undo change to config/default/manager_image_patch.yaml"
+git checkout config/default/manager_image_patch.yaml
+
+# GitHub release flow will take care of tagging, just need a commit for it to point at
+echo "Running 'git add config/releases/$mig_release_tag'"
+git add config/releases/$mig_release_tag
+
+echo "Running 'git commit -m $mig_release_tag --edit'"
+git commit -m "Release $mig_release_tag" --edit
+
+echo
+echo "================= Final steps to release ====================="
+echo "  1. Push the release commit that has just been created"
+echo "  2. Use GitHub release flow to create release from commit"
+echo "  3. Run manual build trigger on quay.io against released tag"
+echo "=============================================================="


### PR DESCRIPTION
First cut at a release script. Release procedure is described in script, relies on script + Github release flow + quay.io

The main thing this accomplishes is a standardized way to dump the generated YAML manifest into a known location: `config/releases/v0.1.0/manifest.yaml`

```
$ hack/release.sh v0.1.0
Patching release image before 'kustomize build config/default'
Writing release manifest to 'config/releases/v0.1.0/manifest.yaml'
Undo change to config/default/manager_image_patch.yaml
Running 'git add config/releases/v0.1.0'
Running 'git commit -m v0.1.0 --edit'
[release-script 3410ffe] Release v0.1.0
 1 file changed, 312 insertions(+)
 create mode 100644 config/releases/v0.1.0/manifest.yaml

================= Final steps to release =====================
  1. Push the release commit that has just been created
  2. Use GitHub release flow to create release from commit
  3. Run manual build trigger on quay.io against released tag
==============================================================
$ 
```