### PR TITLE
Task phases

### DIFF
--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -39,6 +39,7 @@ type MigMigrationStatus struct {
 	MigrationCompleted  bool         `json:"migrationCompleted,omitempty"`
 	StartTimestamp      *metav1.Time `json:"startTimestamp,omitempty"`
 	CompletionTimestamp *metav1.Time `json:"completionTimestamp,omitempty"`
+	TaskPhase           string       `json:"taskPhase,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/migration/v1alpha1/migstage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstage_types.go
@@ -32,15 +32,11 @@ type MigStageSpec struct {
 // MigStageStatus defines the observed state of MigStage
 type MigStageStatus struct {
 	Conditions
-
-	StageRunning   bool `json:"stageStarted,omitempty"`
-	StageCompleted bool `json:"stageCompleted,omitempty"`
-
+	StageRunning        bool         `json:"stageStarted,omitempty"`
+	StageCompleted      bool         `json:"stageCompleted,omitempty"`
 	StartTimestamp      *metav1.Time `json:"startTimestamp,omitempty"`
 	CompletionTimestamp *metav1.Time `json:"completionTimestamp,omitempty"`
-
-	SrcBackupRef   *kapi.ObjectReference `json:"srcBackupRef,omitempty"`
-	DestRestoreRef *kapi.ObjectReference `json:"destRestoreRef,omitempty"`
+	TaskPhase           string       `json:"taskPhase,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
@@ -603,16 +603,6 @@ func (in *MigStageStatus) DeepCopyInto(out *MigStageStatus) {
 		in, out := &in.CompletionTimestamp, &out.CompletionTimestamp
 		*out = (*in).DeepCopy()
 	}
-	if in.SrcBackupRef != nil {
-		in, out := &in.SrcBackupRef, &out.SrcBackupRef
-		*out = new(v1.ObjectReference)
-		**out = **in
-	}
-	if in.DestRestoreRef != nil {
-		in, out := &in.DestRestoreRef, &out.DestRestoreRef
-		*out = new(v1.ObjectReference)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -21,6 +21,7 @@ import (
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
 	"k8s.io/apiserver/pkg/storage/names"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -120,13 +121,17 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	// Do the migration.
-	err = r.migrate(migration)
+	requeue, err := r.migrate(migration)
 	if err != nil {
 		if errors.IsConflict(err) {
 			return reconcile.Result{Requeue: true}, nil
 		} else {
 			return reconcile.Result{}, err
 		}
+	}
+	if requeue {
+		delay := time.Second * 5
+		return reconcile.Result{RequeueAfter: delay}, nil
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/controller/migstage/migstage_controller.go
+++ b/pkg/controller/migstage/migstage_controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	"time"
 )
 
 var log = logf.Log.WithName("stage")
@@ -138,7 +139,7 @@ func (r *ReconcileMigStage) Reconcile(request reconcile.Request) (reconcile.Resu
 		return reconcile.Result{}, err
 	}
 
-	err = r.stage(migStage)
+	requeue, err := r.stage(migStage)
 	if err != nil {
 		if errors.IsConflict(err) {
 			return reconcile.Result{Requeue: true}, nil
@@ -146,5 +147,10 @@ func (r *ReconcileMigStage) Reconcile(request reconcile.Request) (reconcile.Resu
 			return reconcile.Result{}, err
 		}
 	}
+	if requeue {
+		delay := time.Second * 5
+		return reconcile.Result{RequeueAfter: delay}, nil
+	}
+
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
Introduces `Task` phases.  This is needed to support resuming a task by reconcile() trigged by watched resources and polling.  The polling is needed to support Restic pod restarts.  The `Task.Phase` provides Task.Run() caller with simple information used to determine if a reconcile requeue is needed.  It also provides for other conditional behavior without introducing complex state.