### PR TITLE
Add velero prereq, remove mac-unfriendly make samples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ manifests:
 # Copy sample CRs to a new 'migsamples' directory that is in .gitignore to avoid committing SA tokens
 samples:
 	mkdir -p migsamples
-	cp --interactive -v config/samples/* migsamples
+	cp -v config/samples/* migsamples
 
 # Run go fmt against code
 fmt:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
  - golang compiler (tested @ 1.11.5)
  - kubebuilder (tested @ 1.0.7)
  - dep (tested @ v0.5.0)
+ - velero (tested @ v0.11.0) installed on both clusters involved in migration
 
 ---
 


### PR DESCRIPTION
Turns out Macs don't support `cp --interactive` and we never listed Velero as a prereq.