### PR TITLE
Create migration-registry before backup/restore

### DIFF
--- a/pkg/controller/migcluster/remote_watch.go
+++ b/pkg/controller/migcluster/remote_watch.go
@@ -18,8 +18,10 @@ package migcluster
 
 import (
 	"github.com/fusor/mig-controller/pkg/controller/remotewatcher"
+	"github.com/fusor/mig-controller/pkg/imagescheme"
 	"github.com/fusor/mig-controller/pkg/remote"
 	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
+	appsv1 "github.com/openshift/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -41,6 +43,16 @@ func StartRemoteWatch(r *ReconcileMigCluster, config remote.ManagerConfig) error
 	log.Info("[rWatch] Adding Velero to scheme")
 	if err := velerov1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "[rWatch] Unable add Velero APIs to scheme")
+		return err
+	}
+	log.Info("[rWatch] Adding OpenShift imagestream to scheme")
+	if err := imagescheme.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "[rWatch] Unable add OpenShift image APIs to scheme")
+		return err
+	}
+	log.Info("[rWatch] Adding OpenShift deploymentconfig to scheme")
+	if err := appsv1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "[rWatch] Unable add OpenShift apps APIs to scheme")
 		return err
 	}
 

--- a/pkg/controller/remotewatcher/remotewatcher_controller.go
+++ b/pkg/controller/remotewatcher/remotewatcher_controller.go
@@ -82,6 +82,8 @@ type ReconcileRemoteWatcher struct {
 
 // Reconcile reads that state of the cluster for a RemoteWatcher object and makes changes
 // +kubebuilder:rbac:groups=velero.io,resources=*,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=image.openshift.io,resources=*,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps.openshift.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 func (r *ReconcileRemoteWatcher) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Forward a known Event back to the parent controller
 	r.ForwardChannel <- r.ForwardEvent

--- a/pkg/imagescheme/register.go
+++ b/pkg/imagescheme/register.go
@@ -1,0 +1,52 @@
+package imagescheme
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/openshift/api/image/docker10"
+	"github.com/openshift/api/image/dockerpre012"
+	imagev1API "github.com/openshift/api/image/v1"
+)
+
+var (
+	GroupName     = "image.openshift.io"
+	GroupVersion  = schema.GroupVersion{Group: GroupName, Version: "v1"}
+	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes, docker10.AddToScheme, dockerpre012.AddToScheme, corev1.AddToScheme)
+	// Install is a function which adds this version to a scheme
+	Install = schemeBuilder.AddToScheme
+
+	// SchemeGroupVersion generated code relies on this name
+	// Deprecated
+	SchemeGroupVersion = GroupVersion
+	// AddToScheme exists solely to keep the old generators creating valid code
+	// DEPRECATED
+	AddToScheme = schemeBuilder.AddToScheme
+)
+
+// Resource generated code relies on this being here, but it logically belongs to the group
+// DEPRECATED
+func Resource(resource string) schema.GroupResource {
+	return schema.GroupResource{Group: GroupName, Resource: resource}
+}
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&imagev1API.Image{},
+		&imagev1API.ImageList{},
+		&imagev1API.ImageSignature{},
+		&imagev1API.ImageStream{},
+		&imagev1API.ImageStreamList{},
+		&imagev1API.ImageStreamMapping{},
+		&imagev1API.ImageStreamTag{},
+		&imagev1API.ImageStreamTagList{},
+		&imagev1API.ImageStreamImage{},
+		&imagev1API.ImageStreamLayers{},
+		&imagev1API.ImageStreamImport{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/pkg/velerorunner/backup.go
+++ b/pkg/velerorunner/backup.go
@@ -124,15 +124,19 @@ func (t *Task) getVSL() (*velero.VolumeSnapshotLocation, error) {
 
 // Build a Backups as desired for the source cluster.
 func (t *Task) buildBackup() (*velero.Backup, error) {
+	annotations, err := t.getAnnotations(t.SrcRegistryResources)
+	if err != nil {
+		return nil, err
+	}
 	backup := &velero.Backup{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:       t.Owner.GetCorrelationLabels(),
 			GenerateName: t.Owner.GetName() + "-",
 			Namespace:    VeleroNamespace,
-			Annotations:  t.Annotations,
+			Annotations:  annotations,
 		},
 	}
-	err := t.updateBackup(backup)
+	err = t.updateBackup(backup)
 	return backup, err
 }
 
@@ -150,11 +154,11 @@ func (t *Task) updateBackup(backup *velero.Backup) error {
 	backup.Spec = velero.BackupSpec{
 		StorageLocation:         backupLocation.Name,
 		VolumeSnapshotLocations: []string{snapshotLocation.Name},
-		TTL:                metav1.Duration{Duration: 720 * time.Hour},
-		IncludedNamespaces: namespaces,
-		ExcludedNamespaces: []string{},
-		IncludedResources:  t.BackupResources,
-		ExcludedResources:  []string{},
+		TTL:                     metav1.Duration{Duration: 720 * time.Hour},
+		IncludedNamespaces:      namespaces,
+		ExcludedNamespaces:      []string{},
+		IncludedResources:       t.BackupResources,
+		ExcludedResources:       []string{},
 		Hooks: velero.BackupHooks{
 			Resources: []velero.BackupResourceHookSpec{},
 		},

--- a/pkg/velerorunner/registry.go
+++ b/pkg/velerorunner/registry.go
@@ -1,0 +1,551 @@
+package velerorunner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+
+	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
+	appsv1 "github.com/openshift/api/apps/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+	kapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Ensure the migration registry on the source cluster has been created
+// and has the proper settings.
+func (t *Task) ensureSrcMigRegistry() error {
+	t.SrcRegistryResources = &MigRegistryResources{}
+	client, err := t.getSourceClient()
+	if err != nil {
+		return err
+	}
+	return t.ensureMigRegistry(client, t.SrcRegistryResources)
+}
+
+// Ensure the migration registry on the destination cluster has been created
+// and has the proper settings.
+func (t *Task) ensureDestMigRegistry() error {
+	t.DestRegistryResources = &MigRegistryResources{}
+	client, err := t.getDestinationClient()
+	if err != nil {
+		return err
+	}
+	return t.ensureMigRegistry(client, t.DestRegistryResources)
+}
+
+// Ensure the migration registry on the specified cluster has been created
+// and has the proper settings.
+func (t *Task) ensureMigRegistry(client k8sclient.Client, registryResources *MigRegistryResources) error {
+	err := t.ensureRegistrySecret(client, registryResources)
+	if err != nil {
+		return err
+	}
+
+	err = t.ensureRegistryImageStream(client, registryResources)
+	if err != nil {
+		return err
+	}
+
+	err = t.ensureRegistryDC(client, registryResources)
+	if err != nil {
+		return err
+	}
+	err = t.ensureRegistryService(client, registryResources)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Ensure the credentials secret for the migration registry on the specified cluster has been created
+func (t *Task) ensureRegistrySecret(client k8sclient.Client, registryResources *MigRegistryResources) error {
+	newSecret, err := t.buildRegistrySecret()
+	if err != nil {
+		return err
+	}
+	foundSecret, err := t.getRegistrySecret(client)
+	if err != nil {
+		return err
+	}
+	if foundSecret == nil {
+		registryResources.CredSecret = newSecret
+		err = client.Create(context.TODO(), newSecret)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	registryResources.CredSecret = foundSecret
+	if !t.equalsRegistrySecret(newSecret, foundSecret) {
+		t.updateRegistrySecret(foundSecret)
+		err = client.Update(context.TODO(), foundSecret)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Build a credentials Secret as desired for the source cluster.
+func (t *Task) buildRegistrySecret() (*kapi.Secret, error) {
+	secret := &kapi.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:       t.PlanResources.MigPlan.GetCorrelationLabels(),
+			GenerateName: t.PlanResources.MigPlan.GetName() + "-registry-",
+			Namespace:    VeleroNamespace,
+		},
+	}
+	err := t.updateRegistrySecret(secret)
+	return secret, err
+}
+
+// Update a Registry credentials secret as desired for the specified cluster.
+func (t *Task) updateRegistrySecret(secret *kapi.Secret) error {
+	credSecret, err := t.PlanResources.MigStorage.Spec.BackupStorageConfig.GetCredsSecret(t.Client)
+	if err != nil {
+		return err
+	}
+	if credSecret == nil {
+		return migapi.CredSecretNotFound
+	}
+	secret.Data = map[string][]byte{
+		"access_key": []byte(credSecret.Data[migapi.AwsAccessKeyId]),
+		"secret_key": []byte(credSecret.Data[migapi.AwsSecretAccessKey]),
+	}
+	return nil
+}
+
+// Get an existing credentials Secret on the source cluster.
+func (t *Task) getRegistrySecret(client k8sclient.Client) (*kapi.Secret, error) {
+	list := kapi.SecretList{}
+	labels := t.PlanResources.MigPlan.GetCorrelationLabels()
+	err := client.List(
+		context.TODO(),
+		k8sclient.MatchingLabels(labels),
+		&list)
+	if err != nil {
+		return nil, err
+	}
+	if len(list.Items) > 0 {
+		return &list.Items[0], nil
+	}
+
+	return nil, nil
+}
+
+// Determine if two registry credentials secrets are equal.
+// Returns `true` when equal.
+func (t *Task) equalsRegistrySecret(a, b *kapi.Secret) bool {
+	return reflect.DeepEqual(a.Data, b.Data)
+}
+
+// Ensure the imagestream for the migration registry on the specified cluster has been created
+func (t *Task) ensureRegistryImageStream(client k8sclient.Client, registryResources *MigRegistryResources) error {
+	registrySecret := registryResources.CredSecret
+	if registrySecret == nil {
+		return errors.New("migration registry credentials not found")
+	}
+	newImageStream, err := t.buildRegistryImageStream(registrySecret.GetName())
+	if err != nil {
+		return err
+	}
+	foundImageStream, err := t.getRegistryImageStream(client)
+	if err != nil {
+		return err
+	}
+	if foundImageStream == nil {
+		registryResources.ImageStream = newImageStream
+		err = client.Create(context.TODO(), newImageStream)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	registryResources.ImageStream = foundImageStream
+	if !t.equalsRegistryImageStream(newImageStream, foundImageStream) {
+		t.updateRegistryImageStream(foundImageStream)
+		err = client.Update(context.TODO(), foundImageStream)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Build a Registry ImageStream as desired for the source cluster.
+func (t *Task) buildRegistryImageStream(name string) (*imagev1.ImageStream, error) {
+	labels := t.PlanResources.MigPlan.GetCorrelationLabels()
+	labels["app"] = name
+	imagestream := &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    labels,
+			Name:      name,
+			Namespace: VeleroNamespace,
+		},
+	}
+	err := t.updateRegistryImageStream(imagestream)
+	return imagestream, err
+}
+
+// Update a Registry ImageStream as desired for the specified cluster.
+func (t *Task) updateRegistryImageStream(imagestream *imagev1.ImageStream) error {
+	imagestream.Spec = imagev1.ImageStreamSpec{
+		LookupPolicy: imagev1.ImageLookupPolicy{Local: false},
+		Tags: []imagev1.TagReference{
+			imagev1.TagReference{
+				Name: "2",
+				Annotations: map[string]string{
+					"openshift.io/imported-from": "registry:2",
+				},
+				From: &kapi.ObjectReference{
+					Kind: "DockerImage",
+					Name: "registry:2",
+				},
+				Generation:      nil,
+				ImportPolicy:    imagev1.TagImportPolicy{},
+				ReferencePolicy: imagev1.TagReferencePolicy{Type: ""},
+			},
+		},
+	}
+	return nil
+}
+
+// Get an existing registry ImageStream on the specifiedcluster.
+func (t *Task) getRegistryImageStream(client k8sclient.Client) (*imagev1.ImageStream, error) {
+	list := imagev1.ImageStreamList{}
+	labels := t.PlanResources.MigPlan.GetCorrelationLabels()
+	err := client.List(
+		context.TODO(),
+		k8sclient.MatchingLabels(labels),
+		&list)
+	if err != nil {
+		return nil, err
+	}
+	if len(list.Items) > 0 {
+		return &list.Items[0], nil
+	}
+
+	return nil, nil
+}
+
+// Determine if two imagestreams are equal.
+// Returns `true` when equal.
+func (t *Task) equalsRegistryImageStream(a, b *imagev1.ImageStream) bool {
+	if len(a.Spec.Tags) != len(b.Spec.Tags) {
+		return false
+	}
+	for i, tag := range a.Spec.Tags {
+		if !(reflect.DeepEqual(tag.Name, b.Spec.Tags[i].Name) &&
+			reflect.DeepEqual(tag.From, b.Spec.Tags[i].From)) {
+			return false
+		}
+	}
+	return true
+}
+
+// Ensure the deploymentconfig for the migration registry on the specified cluster has been created
+func (t *Task) ensureRegistryDC(client k8sclient.Client, registryResources *MigRegistryResources) error {
+	registrySecret := registryResources.CredSecret
+	if registrySecret == nil {
+		return errors.New("migration registry credentials not found")
+	}
+	name := registrySecret.GetName()
+	// We need the src cluster's registry secret to grab the name to use for the REGISTRY_STORAGE root dir
+	// since src and dest clusters must use the same dir name here, even if the resource names differ
+	srcRegistrySecret := t.SrcRegistryResources.CredSecret
+	if registrySecret == nil {
+		return errors.New("src migration registry credentials not found")
+	}
+	srcName := srcRegistrySecret.GetName()
+	newDC, err := t.buildRegistryDC(name, srcName)
+	if err != nil {
+		return err
+	}
+	foundDC, err := t.getRegistryDC(client)
+	if err != nil {
+		return err
+	}
+	if foundDC == nil {
+		registryResources.DeploymentConfig = newDC
+		err = client.Create(context.TODO(), newDC)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	registryResources.DeploymentConfig = foundDC
+	if !t.equalsRegistryDC(newDC, foundDC) {
+		t.updateRegistryDC(foundDC, name, srcName)
+		err = client.Update(context.TODO(), foundDC)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Build a Registry DeploymentConfig as desired for the source cluster.
+func (t *Task) buildRegistryDC(name, srcName string) (*appsv1.DeploymentConfig, error) {
+	labels := t.PlanResources.MigPlan.GetCorrelationLabels()
+	labels["app"] = name
+	deploymentconfig := &appsv1.DeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    labels,
+			Name:      name,
+			Namespace: VeleroNamespace,
+		},
+	}
+	err := t.updateRegistryDC(deploymentconfig, name, srcName)
+	return deploymentconfig, err
+}
+
+// Update a Registry DeploymentConfig as desired for the specified cluster.
+func (t *Task) updateRegistryDC(deploymentconfig *appsv1.DeploymentConfig, name, srcName string) error {
+	deploymentconfig.Spec = appsv1.DeploymentConfigSpec{
+		Replicas: 1,
+		Selector: map[string]string{
+			"app":              name,
+			"deploymentconfig": name,
+		},
+		Strategy: appsv1.DeploymentStrategy{Resources: kapi.ResourceRequirements{}},
+		Template: &kapi.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Time{},
+				Labels: map[string]string{
+					"app":              name,
+					"deploymentconfig": name,
+				},
+			},
+			Spec: kapi.PodSpec{
+				Containers: []kapi.Container{
+					kapi.Container{
+						Env: []kapi.EnvVar{
+							kapi.EnvVar{
+								Name:  "REGISTRY_STORAGE",
+								Value: "s3",
+							},
+							kapi.EnvVar{
+								Name: "REGISTRY_STORAGE_S3_ACCESSKEY",
+								ValueFrom: &kapi.EnvVarSource{
+									SecretKeyRef: &kapi.SecretKeySelector{
+										LocalObjectReference: kapi.LocalObjectReference{Name: name},
+										Key:                  "access_key",
+									},
+								},
+							},
+							kapi.EnvVar{
+								Name:  "REGISTRY_STORAGE_S3_BUCKET",
+								Value: t.PlanResources.MigStorage.Spec.BackupStorageConfig.AwsBucketName,
+							},
+							kapi.EnvVar{
+								Name:  "REGISTRY_STORAGE_S3_REGION",
+								Value: t.PlanResources.MigStorage.Spec.BackupStorageConfig.AwsRegion,
+							},
+							kapi.EnvVar{
+								Name:  "REGISTRY_STORAGE_S3_ROOTDIRECTORY",
+								Value: "/" + srcName,
+							},
+							kapi.EnvVar{
+								Name: "REGISTRY_STORAGE_S3_SECRETKEY",
+								ValueFrom: &kapi.EnvVarSource{
+									SecretKeyRef: &kapi.SecretKeySelector{
+										LocalObjectReference: kapi.LocalObjectReference{Name: name},
+										Key:                  "secret_key",
+									},
+								},
+							},
+						},
+						Image: "registry:2",
+						Name:  name,
+						Ports: []kapi.ContainerPort{
+							kapi.ContainerPort{
+								ContainerPort: 5000,
+								Protocol:      kapi.ProtocolTCP,
+							},
+						},
+						Resources: kapi.ResourceRequirements{},
+						VolumeMounts: []kapi.VolumeMount{
+							kapi.VolumeMount{
+								MountPath: "/var/lib/registry",
+								Name:      name + "-volume-1",
+							},
+						},
+					},
+				},
+				Volumes: []kapi.Volume{
+					kapi.Volume{
+						Name:         name + "-volume-1",
+						VolumeSource: kapi.VolumeSource{EmptyDir: &kapi.EmptyDirVolumeSource{}},
+					},
+				},
+			},
+		},
+		Test: false,
+		Triggers: appsv1.DeploymentTriggerPolicies{
+			appsv1.DeploymentTriggerPolicy{
+				Type: appsv1.DeploymentTriggerOnConfigChange,
+			},
+		},
+	}
+	return nil
+}
+
+// Get an existing registry DeploymentConfig on the specifiedcluster.
+func (t *Task) getRegistryDC(client k8sclient.Client) (*appsv1.DeploymentConfig, error) {
+	list := appsv1.DeploymentConfigList{}
+	labels := t.PlanResources.MigPlan.GetCorrelationLabels()
+	err := client.List(
+		context.TODO(),
+		k8sclient.MatchingLabels(labels),
+		&list)
+	if err != nil {
+		return nil, err
+	}
+	if len(list.Items) > 0 {
+		return &list.Items[0], nil
+	}
+
+	return nil, nil
+}
+
+// Determine if two deploymentconfigs are equal.
+// Returns `true` when equal.
+func (t *Task) equalsRegistryDC(a, b *appsv1.DeploymentConfig) bool {
+	if !(reflect.DeepEqual(a.Spec.Replicas, b.Spec.Replicas) &&
+		reflect.DeepEqual(a.Spec.Selector, b.Spec.Selector) &&
+		reflect.DeepEqual(a.Spec.Template.ObjectMeta, b.Spec.Template.ObjectMeta) &&
+		reflect.DeepEqual(a.Spec.Template.Spec.Volumes, b.Spec.Template.Spec.Volumes) &&
+		len(a.Spec.Template.Spec.Containers) == len(b.Spec.Template.Spec.Containers) &&
+		len(a.Spec.Triggers) == len(b.Spec.Triggers)) {
+		return false
+	}
+	for i, container := range a.Spec.Template.Spec.Containers {
+		if !(reflect.DeepEqual(container.Env, b.Spec.Template.Spec.Containers[i].Env) &&
+			reflect.DeepEqual(container.Name, b.Spec.Template.Spec.Containers[i].Name) &&
+			reflect.DeepEqual(container.Ports, b.Spec.Template.Spec.Containers[i].Ports) &&
+			reflect.DeepEqual(container.VolumeMounts, b.Spec.Template.Spec.Containers[i].VolumeMounts)) {
+			return false
+		}
+	}
+	for i, trigger := range a.Spec.Triggers {
+		if !reflect.DeepEqual(trigger, b.Spec.Triggers[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// Ensure the service for the migration registry on the specified cluster has been created
+func (t *Task) ensureRegistryService(client k8sclient.Client, registryResources *MigRegistryResources) error {
+	registrySecret := registryResources.CredSecret
+	if registrySecret == nil {
+		return errors.New("migration registry credentials not found")
+	}
+	name := registrySecret.GetName()
+	newService, err := t.buildRegistryService(name)
+	if err != nil {
+		return err
+	}
+	foundService, err := t.getRegistryService(client)
+	if err != nil {
+		return err
+	}
+	if foundService == nil {
+		registryResources.Service = newService
+		err = client.Create(context.TODO(), newService)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	registryResources.Service = foundService
+	if !t.equalsRegistryService(newService, foundService) {
+		t.updateRegistryService(foundService, name)
+		err = client.Update(context.TODO(), foundService)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Build a Registry Service as desired for the specified cluster.
+func (t *Task) buildRegistryService(name string) (*kapi.Service, error) {
+	labels := t.PlanResources.MigPlan.GetCorrelationLabels()
+	labels["app"] = name
+	service := &kapi.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    labels,
+			Name:      name,
+			Namespace: VeleroNamespace,
+		},
+	}
+	err := t.updateRegistryService(service, name)
+	return service, err
+}
+
+// Update a Registry Service as desired for the specified cluster.
+func (t *Task) updateRegistryService(service *kapi.Service, name string) error {
+	service.Spec = kapi.ServiceSpec{
+		Ports: []kapi.ServicePort{
+			kapi.ServicePort{
+				Name:       "5000-tcp",
+				Port:       5000,
+				Protocol:   kapi.ProtocolTCP,
+				TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 5000},
+			},
+		},
+		Selector: map[string]string{
+			"app":              name,
+			"deploymentconfig": name,
+		},
+	}
+	return nil
+}
+
+// Get an existing registry Service on the specifiedcluster.
+func (t *Task) getRegistryService(client k8sclient.Client) (*kapi.Service, error) {
+	list := kapi.ServiceList{}
+	labels := t.PlanResources.MigPlan.GetCorrelationLabels()
+	err := client.List(
+		context.TODO(),
+		k8sclient.MatchingLabels(labels),
+		&list)
+	if err != nil {
+		return nil, err
+	}
+	if len(list.Items) > 0 {
+		return &list.Items[0], nil
+	}
+
+	return nil, nil
+}
+
+// Determine if two services are equal.
+// Returns `true` when equal.
+func (t *Task) equalsRegistryService(a, b *kapi.Service) bool {
+	return reflect.DeepEqual(a.Spec.Ports, b.Spec.Ports) &&
+		reflect.DeepEqual(a.Spec.Selector, b.Spec.Selector)
+}
+
+// Returns the right backup/restore annotations including registry-specific ones
+func (t *Task) getAnnotations(registryResources *MigRegistryResources) (map[string]string, error) {
+	annotations := t.Annotations
+	if len(registryResources.Service.Spec.Ports) == 0 {
+		return nil, errors.New("Migration Registry service port not found")
+	}
+	annotations[MigRegistryAnnotationKey] = fmt.Sprintf("%s:%d", registryResources.Service.Spec.ClusterIP,
+		registryResources.Service.Spec.Ports[0].Port)
+	for _, container := range registryResources.DeploymentConfig.Spec.Template.Spec.Containers {
+		for _, envVar := range container.Env {
+			if envVar.Name == "REGISTRY_STORAGE_S3_ROOTDIRECTORY" {
+				annotations[MigRegistryDirAnnotationKey] = envVar.Value
+			}
+		}
+	}
+	return annotations, nil
+}

--- a/pkg/velerorunner/restore.go
+++ b/pkg/velerorunner/restore.go
@@ -10,7 +10,10 @@ import (
 // Ensure the restore on the destination cluster has been
 // created  and has the proper settings.
 func (t *Task) ensureRestore() error {
-	newRestore := t.buildRestore()
+	newRestore, err := t.buildRestore()
+	if err != nil {
+		return err
+	}
 	foundRestore, err := t.getRestore()
 	if err != nil {
 		return err
@@ -73,17 +76,21 @@ func (t Task) getRestore() (*velero.Restore, error) {
 }
 
 // Build a Restore as desired for the destination cluster.
-func (t *Task) buildRestore() *velero.Restore {
+func (t *Task) buildRestore() (*velero.Restore, error) {
+	annotations, err := t.getAnnotations(t.DestRegistryResources)
+	if err != nil {
+		return nil, err
+	}
 	restore := &velero.Restore{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:       t.Owner.GetCorrelationLabels(),
 			GenerateName: t.Owner.GetName() + "-",
 			Namespace:    VeleroNamespace,
-			Annotations:  t.Annotations,
+			Annotations:  annotations,
 		},
 	}
 	t.updateRestore(restore)
-	return restore
+	return restore, nil
 }
 
 // Update a Restore as desired for the destination cluster.

--- a/pkg/velerorunner/task.go
+++ b/pkg/velerorunner/task.go
@@ -4,6 +4,9 @@ import (
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/go-logr/logr"
 	velero "github.com/heptio/velero/pkg/apis/velero/v1"
+	appsv1 "github.com/openshift/api/apps/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+	kapi "k8s.io/api/core/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,16 +39,34 @@ const (
 // Backup - A Backup created on the source cluster.
 // Restore - A Restore created on the destination cluster.
 type Task struct {
-	Log             logr.Logger
-	Client          k8sclient.Client
-	Owner           migapi.MigResource
-	PlanResources   *migapi.PlanResources
-	Annotations     map[string]string
-	BackupResources []string
-	Phase           string
-	Backup          *velero.Backup
-	Restore         *velero.Restore
+	Log                   logr.Logger
+	Client                k8sclient.Client
+	Owner                 migapi.MigResource
+	PlanResources         *migapi.PlanResources
+	Annotations           map[string]string
+	BackupResources       []string
+	Phase                 string
+	Backup                *velero.Backup
+	Restore               *velero.Restore
+	SrcRegistryResources  *MigRegistryResources
+	DestRegistryResources *MigRegistryResources
 }
+
+// The set of resources associated with a source or destination
+// Migration Registry.
+// CredSecret -       A secret containing the credentials for the registry storage
+// ImageStream -      The ImageStream resource pointing to the image used by the Registry DeploymentConfig
+// DeploymentConfig - The DeploymentConfig that runs the Migration Registry
+// Service          - The Service resource for the Migration Registry
+type MigRegistryResources struct {
+	CredSecret       *kapi.Secret
+	ImageStream      *imagev1.ImageStream
+	DeploymentConfig *appsv1.DeploymentConfig
+	Service          *kapi.Service
+}
+
+const MigRegistryAnnotationKey string = "openshift.io/migration-registry"
+const MigRegistryDirAnnotationKey string = "openshift.io/migration-registry-dir"
 
 // Reconcile() Example:
 //
@@ -81,6 +102,11 @@ func (t *Task) Run() error {
 		return nil
 	}
 
+	// Source Migration Registry
+	err = t.ensureSrcMigRegistry()
+	if err != nil {
+		return err
+	}
 	// Backup
 	err = t.ensureBackup()
 	if err != nil {
@@ -105,6 +131,11 @@ func (t *Task) Run() error {
 		return nil
 	}
 
+	// Destination Migration Registry
+	err = t.ensureDestMigRegistry()
+	if err != nil {
+		return err
+	}
 	// Restore
 	err = t.ensureRestore()
 	if err != nil {


### PR DESCRIPTION
Create the migration registry deploymentconfig and related
resources (secret, imagestream, service) in source and destination
clusters before starting backup or restore.