### PR TITLE
Use client with cache when possible

### DIFF
--- a/pkg/controller/migcluster/migcluster_controller.go
+++ b/pkg/controller/migcluster/migcluster_controller.go
@@ -18,10 +18,12 @@ package migcluster
 
 import (
 	"context"
+
 	"k8s.io/apiserver/pkg/storage/names"
 
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
+	"github.com/fusor/mig-controller/pkg/remote"
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -142,7 +144,7 @@ func (r *ReconcileMigCluster) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Create a Remote Watch for this MigCluster if one doesn't exist
-	remoteWatchMap := GetRemoteWatchMap()
+	remoteWatchMap := remote.GetWatchMap()
 	remoteWatchCluster := remoteWatchMap.Get(request.NamespacedName)
 
 	if remoteWatchCluster == nil {
@@ -161,10 +163,11 @@ func (r *ReconcileMigCluster) Reconcile(request reconcile.Request) (reconcile.Re
 			}
 		}
 
-		StartRemoteWatch(r, RemoteManagerConfig{
+		StartRemoteWatch(r, remote.ManagerConfig{
 			RemoteRestConfig: restCfg,
 			ParentNsName:     request.NamespacedName,
-			ParentResource:   migCluster,
+			ParentMeta:       migCluster.GetObjectMeta(),
+			ParentObject:     migCluster,
 		})
 
 		log.Info("Remote watch started.", "cluster", request.Name)

--- a/pkg/controller/migcluster/remote_watch.go
+++ b/pkg/controller/migcluster/remote_watch.go
@@ -17,41 +17,20 @@ limitations under the License.
 package migcluster
 
 import (
-	"sync"
-
 	"github.com/fusor/mig-controller/pkg/controller/remotewatcher"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/rest"
+	"github.com/fusor/mig-controller/pkg/remote"
+	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-
-	migrationv1alpha1 "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
-	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
 )
-
-var rwmInstance *RemoteWatchMap
-var createRemoteWatchMapOnce sync.Once
-
-// RemoteManagerConfig specifies config options for setting up a RemoteWatch Manager
-type RemoteManagerConfig struct {
-	// rest.Config for remote cluster to watch Velero events on
-	RemoteRestConfig *rest.Config
-	// nsname used in mapping MigCluster resources to RemoteWatchManagers
-	ParentNsName types.NamespacedName
-	// MigMigration object containing v1.Object and runtime.Object needed for remote cluster to properly forward events
-	ParentResource *migrationv1alpha1.MigCluster
-}
-
-// TODO: add support for forwarding events to multiple channels so that MigStage and
-// MigMigration controllers can also be notified of Velero events on remote clusters.
 
 // StartRemoteWatch will configure a new RemoteWatcher manager + controller to monitor Velero
 // events on a remote cluster. A GenericEvent channel will be configured to funnel events from
 // the RemoteWatcher controller to the MigCluster controller.
-func StartRemoteWatch(r *ReconcileMigCluster, config RemoteManagerConfig) error {
-	remoteWatchMap := GetRemoteWatchMap()
+func StartRemoteWatch(r *ReconcileMigCluster, config remote.ManagerConfig) error {
+	remoteWatchMap := remote.GetWatchMap()
 
 	mgr, err := manager.New(config.RemoteRestConfig, manager.Options{})
 	if err != nil {
@@ -78,8 +57,8 @@ func StartRemoteWatch(r *ReconcileMigCluster, config RemoteManagerConfig) error 
 	// Add remoteWatcher to remote MGR
 	log.Info("[rWatch] Adding controller to manager")
 	forwardEvent := event.GenericEvent{
-		Meta:   config.ParentResource.GetObjectMeta(),
-		Object: config.ParentResource,
+		Meta:   config.ParentMeta,
+		Object: config.ParentObject,
 	}
 	err = remotewatcher.Add(mgr, forwardChannel, forwardEvent)
 	if err != nil {
@@ -95,58 +74,11 @@ func StartRemoteWatch(r *ReconcileMigCluster, config RemoteManagerConfig) error 
 	log.Info("[rWatch] Manager started")
 	// TODO: provide a way to dynamically change where events are being forwarded to (multiple controllers)
 	// Create remoteWatchCluster tracking obj and attach reference to parent object so we don't create extra
-	remoteWatchCluster := &RemoteWatchCluster{ForwardChannel: forwardChannel, RemoteManager: mgr}
+	remoteWatchCluster := &remote.WatchCluster{ForwardChannel: forwardChannel, RemoteManager: mgr}
 
 	// MigClusters have a 1:1 association with a RemoteWatchCluster, so we will store the mapping
 	// to avoid creating duplicate remote managers in the future.
 	remoteWatchMap.Set(config.ParentNsName, remoteWatchCluster)
 
 	return nil
-}
-
-// RemoteWatchCluster tracks Remote Managers and Event Forward Channels
-type RemoteWatchCluster struct {
-	ForwardChannel chan event.GenericEvent
-	RemoteManager  manager.Manager
-	//  TODO - setup stop channel for manager so that manager will stop when we close the event channel from parent
-}
-
-// RemoteWatchMap provides a map between MigCluster nsNames and RemoteWatchClusters
-type RemoteWatchMap struct {
-	mutex                 sync.RWMutex
-	nsNameToRemoteCluster map[types.NamespacedName]*RemoteWatchCluster
-}
-
-// GetRemoteWatchMap returns the shared RemoteWatchMap instance
-func GetRemoteWatchMap() *RemoteWatchMap {
-	createRemoteWatchMapOnce.Do(func() {
-		rwmInstance = &RemoteWatchMap{}
-		rwmInstance.nsNameToRemoteCluster = make(map[types.NamespacedName]*RemoteWatchCluster)
-	})
-	return rwmInstance
-}
-
-// Get the RemoteWatchCluster associated with a MigCluster resource nsName, return nil if not found
-func (r *RemoteWatchMap) Get(key types.NamespacedName) *RemoteWatchCluster {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-	rwc, ok := rwmInstance.nsNameToRemoteCluster[key]
-	if !ok {
-		return nil
-	}
-	return rwc
-}
-
-// Set the RemoteWatchCluster associated with a MigCluster resource nsName
-func (r *RemoteWatchMap) Set(key types.NamespacedName, value *RemoteWatchCluster) {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	rwmInstance.nsNameToRemoteCluster[key] = value
-}
-
-// Delete the RemoteWatchCluster associated with a MigCluster resource nsName
-func (r *RemoteWatchMap) Delete(key types.NamespacedName) {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	delete(rwmInstance.nsNameToRemoteCluster, key)
 }

--- a/pkg/remote/watch.go
+++ b/pkg/remote/watch.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2019 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var rwmInstance *WatchMap
+var createRemoteWatchMapOnce sync.Once
+
+// ManagerConfig specifies config options for setting up a RemoteWatch Manager
+type ManagerConfig struct {
+	// rest.Config for remote cluster to watch Velero events on
+	RemoteRestConfig *rest.Config
+	// nsname used in mapping MigCluster resources to RemoteWatchManagers
+	ParentNsName types.NamespacedName
+	// MigMigration v1.Object and runtime.Object needed for remote cluster to properly forward events
+	ParentMeta   v1.Object
+	ParentObject runtime.Object
+}
+
+// TODO: add support for forwarding events to multiple channels so that MigStage and
+// MigMigration controllers can also be notified of Velero events on remote clusters.
+
+// WatchCluster tracks Remote Managers and Event Forward Channels
+type WatchCluster struct {
+	ForwardChannel chan event.GenericEvent
+	RemoteManager  manager.Manager
+	//  TODO - setup stop channel for manager so that manager will stop when we close the event channel from parent
+}
+
+// WatchMap provides a map between MigCluster nsNames and RemoteWatchClusters
+type WatchMap struct {
+	mutex                 sync.RWMutex
+	nsNameToRemoteCluster map[types.NamespacedName]*WatchCluster
+}
+
+// GetWatchMap returns the shared RemoteWatchMap instance
+func GetWatchMap() *WatchMap {
+	createRemoteWatchMapOnce.Do(func() {
+		rwmInstance = &WatchMap{}
+		rwmInstance.nsNameToRemoteCluster = make(map[types.NamespacedName]*WatchCluster)
+	})
+	return rwmInstance
+}
+
+// Get the RemoteWatchCluster associated with a MigCluster resource nsName, return nil if not found
+func (r *WatchMap) Get(key types.NamespacedName) *WatchCluster {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	rwc, ok := rwmInstance.nsNameToRemoteCluster[key]
+	if !ok {
+		return nil
+	}
+	return rwc
+}
+
+// Set the RemoteWatchCluster associated with a MigCluster resource nsName
+func (r *WatchMap) Set(key types.NamespacedName, value *WatchCluster) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	rwmInstance.nsNameToRemoteCluster[key] = value
+}
+
+// Delete the RemoteWatchCluster associated with a MigCluster resource nsName
+func (r *WatchMap) Delete(key types.NamespacedName) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	delete(rwmInstance.nsNameToRemoteCluster, key)
+}


### PR DESCRIPTION
- For remote clusters, re-use the controller-runtime client that is hooked up with a cache
  - We are able to get this client from the remote watch map, which maps from `MigCluster` resources to remote managers.
  - Each remote manager has a `GetClient()` method which we can use to get a client hooked into its cache

- Moved some remote watch code to new `remote` pkg in `watch.go` to facilitate the above
  - Renamed some funcs / vars here as well