### PR TITLE
Add critical condition category.

### DIFF
--- a/pkg/apis/migration/v1alpha1/condition.go
+++ b/pkg/apis/migration/v1alpha1/condition.go
@@ -17,13 +17,15 @@ const (
 )
 
 // Category
-// Required - Required for the `Ready` condition.
+// Critical - Errors that block Reconcile() and the `Ready` condition.
 // Error - Errors that block the `Ready` condition.
-// Warning - Warnings that block the `Ready` condition.
+// Warn - Warnings that do not block the `Ready` condition.
+// Required - Required for the `Ready` condition.
 const (
+	Critical = "Critical"
 	Error    = "Error"
-	Required = "Required"
 	Warn     = "Warn"
+	Required = "Required"
 )
 
 // Condition
@@ -201,6 +203,12 @@ func (r *Conditions) HasConditionCategory(names ...string) bool {
 	return false
 }
 
+// The collection contains a `Critical` error condition.
+// Resource reconcile() should not continue.
+func (r *Conditions) HasCriticalCondition(category ...string) bool {
+	return r.HasConditionCategory(Critical)
+}
+
 // The collection contains an `Error` condition.
 func (r *Conditions) HasErrorCondition(category ...string) bool {
 	return r.HasConditionCategory(Error)
@@ -208,12 +216,12 @@ func (r *Conditions) HasErrorCondition(category ...string) bool {
 
 // The collection contains a `Warn` condition.
 func (r *Conditions) HasWarnCondition(category ...string) bool {
-	return r.HasConditionCategory(Error)
+	return r.HasConditionCategory(Warn)
 }
 
 // The collection contains a `Ready` blocker condition.
 func (r *Conditions) HasBlockerCondition() bool {
-	return r.HasConditionCategory(Error, Warn)
+	return r.HasConditionCategory(Critical, Error)
 }
 
 // Set `Ready` condition.

--- a/pkg/controller/migassetcollection/validation.go
+++ b/pkg/controller/migassetcollection/validation.go
@@ -10,6 +10,11 @@ const (
 	EmptyCollection = "EmptyCollection"
 )
 
+// Categories
+const (
+	Critical = migapi.Critical
+)
+
 // Reasons
 const (
 	NotFound = "NotFound"
@@ -65,7 +70,7 @@ func (r ReconcileMigAssetCollection) validateEmpty(assetCollection *migapi.MigAs
 		assetCollection.Status.SetCondition(migapi.Condition{
 			Type:     EmptyCollection,
 			Status:   True,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  EmptyCollectionMessage,
 		})
 		return nil

--- a/pkg/controller/migcluster/validation.go
+++ b/pkg/controller/migcluster/validation.go
@@ -19,6 +19,11 @@ const (
 	TestConnectFailed  = "TestConnectFailed"
 )
 
+// Categories
+const (
+	Critical = migapi.Critical
+)
+
 // Reasons
 const (
 	NotSet        = "NotSet"
@@ -93,7 +98,7 @@ func (r ReconcileMigCluster) validateRegistryCluster(cluster *migapi.MigCluster)
 			Type:     InvalidClusterRef,
 			Status:   True,
 			Reason:   NotSet,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidClusterRefMessage,
 		})
 		return nil
@@ -110,7 +115,7 @@ func (r ReconcileMigCluster) validateRegistryCluster(cluster *migapi.MigCluster)
 			Type:     InvalidClusterRef,
 			Status:   True,
 			Reason:   NotFound,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidClusterRefMessage,
 		})
 		return nil
@@ -156,7 +161,7 @@ func (r ReconcileMigCluster) validateSaSecret(cluster *migapi.MigCluster) error 
 			Type:     InvalidSaSecretRef,
 			Status:   True,
 			Reason:   NotSet,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidSaSecretRefMessage,
 		})
 		return nil
@@ -173,7 +178,7 @@ func (r ReconcileMigCluster) validateSaSecret(cluster *migapi.MigCluster) error 
 			Type:     InvalidSaSecretRef,
 			Status:   True,
 			Reason:   NotFound,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidSaSecretRefMessage,
 		})
 		return nil
@@ -186,7 +191,7 @@ func (r ReconcileMigCluster) validateSaSecret(cluster *migapi.MigCluster) error 
 			Type:     InvalidSaToken,
 			Status:   True,
 			Reason:   NotFound,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidSaTokenMessage,
 		})
 		return nil
@@ -196,7 +201,7 @@ func (r ReconcileMigCluster) validateSaSecret(cluster *migapi.MigCluster) error 
 			Type:     InvalidSaToken,
 			Status:   True,
 			Reason:   NotSet,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidSaTokenMessage,
 		})
 		return nil
@@ -220,7 +225,7 @@ func (r ReconcileMigCluster) testConnection(cluster *migapi.MigCluster) error {
 			Type:     TestConnectFailed,
 			Status:   True,
 			Reason:   ConnectFailed,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  message,
 		})
 		return nil

--- a/pkg/controller/migcluster/validation.go
+++ b/pkg/controller/migcluster/validation.go
@@ -215,7 +215,7 @@ func (r ReconcileMigCluster) testConnection(cluster *migapi.MigCluster) error {
 	if cluster.Spec.IsHostCluster {
 		return nil
 	}
-	if cluster.Status.HasErrorCondition() {
+	if cluster.Status.HasCriticalCondition() {
 		return nil
 	}
 	_, err := cluster.GetClient(r)

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -13,6 +13,11 @@ const (
 	PlanNotReady   = "PlanNotReady"
 )
 
+// Categories
+const (
+	Critical = migapi.Critical
+)
+
 // Reasons
 const (
 	NotSet   = "NotSet"
@@ -69,7 +74,7 @@ func (r ReconcileMigMigration) validatePlan(migration *migapi.MigMigration) erro
 			Type:     InvalidPlanRef,
 			Status:   True,
 			Reason:   NotSet,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidPlanRefMessage,
 		})
 		return nil
@@ -86,7 +91,7 @@ func (r ReconcileMigMigration) validatePlan(migration *migapi.MigMigration) erro
 			Type:     InvalidPlanRef,
 			Status:   True,
 			Reason:   NotFound,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidPlanRefMessage,
 		})
 		return nil
@@ -97,7 +102,7 @@ func (r ReconcileMigMigration) validatePlan(migration *migapi.MigMigration) erro
 		migration.Status.SetCondition(migapi.Condition{
 			Type:     PlanNotReady,
 			Status:   True,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  PlanNotReadyMessage,
 		})
 		return nil

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -142,7 +142,7 @@ func (r *ReconcileMigPlan) Reconcile(request reconcile.Request) (reconcile.Resul
 			return reconcile.Result{}, err
 		}
 	}
-	if plan.Status.HasErrorCondition() {
+	if plan.Status.HasCriticalCondition() {
 		plan.Status.SetReady(false, ReadyMessage)
 		err = r.Update(context.TODO(), plan)
 		if err != nil {

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -31,6 +31,11 @@ const (
 	StorageEnsured                 = "StorageEnsured"
 )
 
+// Categories
+const (
+	Critical = migapi.Critical
+)
+
 // Reasons
 const (
 	NotSet      = "NotSet"
@@ -116,7 +121,7 @@ func (r ReconcileMigPlan) validateStorage(plan *migapi.MigPlan) error {
 			Type:     InvalidStorageRef,
 			Status:   True,
 			Reason:   NotSet,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidStorageRefMessage,
 		})
 		return nil
@@ -133,7 +138,7 @@ func (r ReconcileMigPlan) validateStorage(plan *migapi.MigPlan) error {
 			Type:     InvalidStorageRef,
 			Status:   True,
 			Reason:   NotFound,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidStorageRefMessage,
 		})
 		return nil
@@ -144,7 +149,7 @@ func (r ReconcileMigPlan) validateStorage(plan *migapi.MigPlan) error {
 		plan.Status.SetCondition(migapi.Condition{
 			Type:     StorageNotReady,
 			Status:   True,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  StorageNotReadyMessage,
 		})
 		return nil
@@ -163,7 +168,7 @@ func (r ReconcileMigPlan) validateAssetCollection(plan *migapi.MigPlan) error {
 			Type:     InvalidAssetCollectionRef,
 			Status:   True,
 			Reason:   NotSet,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidAssetCollectionRefMessage,
 		})
 		return nil
@@ -180,7 +185,7 @@ func (r ReconcileMigPlan) validateAssetCollection(plan *migapi.MigPlan) error {
 			Type:     InvalidAssetCollectionRef,
 			Status:   True,
 			Reason:   NotFound,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidAssetCollectionRefMessage,
 		})
 		return nil
@@ -191,7 +196,7 @@ func (r ReconcileMigPlan) validateAssetCollection(plan *migapi.MigPlan) error {
 		plan.Status.SetCondition(migapi.Condition{
 			Type:     AssetCollectionNotReady,
 			Status:   True,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  AssetCollectionNotReadyMessage,
 		})
 		return nil
@@ -229,7 +234,7 @@ func (r ReconcileMigPlan) validateAssetCollection(plan *migapi.MigPlan) error {
 			Type:     AssetNamespaceNotFound,
 			Status:   True,
 			Reason:   NotFound,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  message,
 		})
 		return nil
@@ -248,7 +253,7 @@ func (r ReconcileMigPlan) validateSourceCluster(plan *migapi.MigPlan) error {
 			Type:     InvalidSourceClusterRef,
 			Status:   True,
 			Reason:   NotSet,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidSourceClusterRefMessage,
 		})
 		return nil
@@ -265,7 +270,7 @@ func (r ReconcileMigPlan) validateSourceCluster(plan *migapi.MigPlan) error {
 			Type:     InvalidSourceClusterRef,
 			Status:   True,
 			Reason:   NotFound,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidSourceClusterRefMessage,
 		})
 		return nil
@@ -276,7 +281,7 @@ func (r ReconcileMigPlan) validateSourceCluster(plan *migapi.MigPlan) error {
 		plan.Status.SetCondition(migapi.Condition{
 			Type:     SourceClusterNotReady,
 			Status:   True,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  SourceClusterNotReadyMessage,
 		})
 		return nil
@@ -295,7 +300,7 @@ func (r ReconcileMigPlan) validateDestinationCluster(plan *migapi.MigPlan) error
 			Type:     InvalidDestinationClusterRef,
 			Status:   True,
 			Reason:   NotSet,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidDestinationClusterRefMessage,
 		})
 		return nil
@@ -307,7 +312,7 @@ func (r ReconcileMigPlan) validateDestinationCluster(plan *migapi.MigPlan) error
 			Type:     InvalidDestinationCluster,
 			Status:   True,
 			Reason:   NotDistinct,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidDestinationClusterMessage,
 		})
 		return nil
@@ -324,7 +329,7 @@ func (r ReconcileMigPlan) validateDestinationCluster(plan *migapi.MigPlan) error
 			Type:     InvalidDestinationClusterRef,
 			Status:   True,
 			Reason:   NotFound,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidDestinationClusterRefMessage,
 		})
 		return nil
@@ -335,7 +340,7 @@ func (r ReconcileMigPlan) validateDestinationCluster(plan *migapi.MigPlan) error
 		plan.Status.SetCondition(migapi.Condition{
 			Type:     DestinationClusterNotReady,
 			Status:   True,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  DestinationClusterNotReadyMessage,
 		})
 		return nil
@@ -396,7 +401,7 @@ func (r ReconcileMigPlan) validateSourceNamespaces(plan *migapi.MigPlan) error {
 			Type:     NsNotFoundOnSourceCluster,
 			Status:   True,
 			Reason:   NotFound,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  message,
 		})
 		return nil
@@ -440,7 +445,7 @@ func (r ReconcileMigPlan) validateDestinationNamespaces(plan *migapi.MigPlan) er
 			Type:     NsNotFoundOnDestinationCluster,
 			Status:   True,
 			Reason:   NotFound,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  message,
 		})
 		return nil

--- a/pkg/controller/migstage/validation.go
+++ b/pkg/controller/migstage/validation.go
@@ -13,6 +13,11 @@ const (
 	PlanNotReady   = "PlanNotReady"
 )
 
+// Categories
+const (
+	Critical = migapi.Critical
+)
+
 // Reasons
 const (
 	NotSet   = "NotSet"
@@ -67,7 +72,7 @@ func (r ReconcileMigStage) validatePlan(stage *migapi.MigStage) error {
 			Type:     InvalidPlanRef,
 			Status:   True,
 			Reason:   NotSet,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidPlanRefMessage,
 		})
 		return nil
@@ -84,7 +89,7 @@ func (r ReconcileMigStage) validatePlan(stage *migapi.MigStage) error {
 			Type:     InvalidPlanRef,
 			Status:   True,
 			Reason:   NotFound,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidPlanRefMessage,
 		})
 		return nil
@@ -95,7 +100,7 @@ func (r ReconcileMigStage) validatePlan(stage *migapi.MigStage) error {
 		stage.Status.SetCondition(migapi.Condition{
 			Type:     PlanNotReady,
 			Status:   True,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  PlanNotReadyMessage,
 		})
 		return nil

--- a/pkg/controller/migstorage/validation.go
+++ b/pkg/controller/migstorage/validation.go
@@ -23,6 +23,11 @@ const (
 	InvalidVSLCredsSecret    = "InvalidVolumeSnapshotCredsSecret"
 )
 
+// Categories
+const (
+	Critical = migapi.Critical
+)
+
 // Reasons
 const (
 	Supported      = "Supported"
@@ -100,7 +105,7 @@ func (r ReconcileMigStorage) validateBSL(storage *migapi.MigStorage) error {
 			Type:     InvalidBSLProvider,
 			Status:   True,
 			Reason:   NotSupported,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidBSLProviderMessage,
 		})
 		return nil
@@ -142,7 +147,7 @@ func (r ReconcileMigStorage) validateAwsBSLSettings(storage *migapi.MigStorage) 
 		storage.Status.SetCondition(migapi.Condition{
 			Type:     InvalidBSLProvider,
 			Status:   True,
-			Category: migapi.Error,
+			Category: Critical,
 			Reason:   InvalidSetting,
 			Message:  message,
 		})
@@ -170,7 +175,7 @@ func (r ReconcileMigStorage) validateAzureBSLSettings(storage *migapi.MigStorage
 		storage.Status.SetCondition(migapi.Condition{
 			Type:     InvalidBSLProvider,
 			Status:   True,
-			Category: migapi.Error,
+			Category: Critical,
 			Reason:   InvalidSetting,
 			Message:  message,
 		})
@@ -193,7 +198,7 @@ func (r ReconcileMigStorage) validateBSLCredsSecret(storage *migapi.MigStorage) 
 			Type:     InvalidBSLCredsSecretRef,
 			Status:   True,
 			Reason:   NotSet,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidBSLCredsSecretRefMessage,
 		})
 		return nil
@@ -210,7 +215,7 @@ func (r ReconcileMigStorage) validateBSLCredsSecret(storage *migapi.MigStorage) 
 			Type:     InvalidBSLCredsSecretRef,
 			Status:   True,
 			Reason:   NotFound,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidBSLCredsSecretRefMessage,
 		})
 		return nil
@@ -222,7 +227,7 @@ func (r ReconcileMigStorage) validateBSLCredsSecret(storage *migapi.MigStorage) 
 			Type:     InvalidBSLCredsSecret,
 			Status:   True,
 			Reason:   KeyError,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidBSLCredsSecretMessage,
 		})
 		return nil
@@ -248,7 +253,7 @@ func (r ReconcileMigStorage) validateVSL(storage *migapi.MigStorage) error {
 			Type:     InvalidVSLProvider,
 			Status:   True,
 			Reason:   NotSupported,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidVSLProviderMessage,
 		})
 		return nil
@@ -278,7 +283,7 @@ func (r ReconcileMigStorage) validateAwsVSLSettings(storage *migapi.MigStorage) 
 			Type:     InvalidVSLProvider,
 			Status:   True,
 			Reason:   InvalidSetting,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  message,
 		})
 		return nil
@@ -306,7 +311,7 @@ func (r ReconcileMigStorage) validateAzureVSLSettings(storage *migapi.MigStorage
 			Type:     InvalidVSLProvider,
 			Status:   True,
 			Reason:   InvalidSetting,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  message,
 		})
 		return nil
@@ -328,7 +333,7 @@ func (r ReconcileMigStorage) validateVSLCredsSecret(storage *migapi.MigStorage) 
 			Type:     InvalidVSLCredsSecretRef,
 			Status:   True,
 			Reason:   NotSet,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidVSLCredsSecretRefMessage,
 		})
 		return nil
@@ -345,7 +350,7 @@ func (r ReconcileMigStorage) validateVSLCredsSecret(storage *migapi.MigStorage) 
 			Type:     InvalidVSLCredsSecretRef,
 			Status:   True,
 			Reason:   NotFound,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidVSLCredsSecretRefMessage,
 		})
 		return nil
@@ -357,7 +362,7 @@ func (r ReconcileMigStorage) validateVSLCredsSecret(storage *migapi.MigStorage) 
 			Type:     InvalidVSLCredsSecret,
 			Status:   True,
 			Reason:   KeyError,
-			Category: migapi.Error,
+			Category: Critical,
 			Message:  InvalidVSLCredsSecretMessage,
 		})
 		return nil


### PR DESCRIPTION
Add a `Critical` condition category for error conditions that prevent Reconcile() from continuing beyond validation.  Mostly used for _validation_ errors.  `Critical` & `Error` conditions will block the `Ready` condition.  `Warn` no longer will.