### PR TITLE
Update README.md to be more new-user friendly, add HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,51 @@
+# Hacking on mig-controller
+
+## Building and running mig-controller with `make run`
+
+__1. Install prerequisites__
+https://github.com/fusor/mig-controller#prerequisites
+
+__2. Create required CRDs (MigMigration, MigPlan, MigCluster, Cluster...)__
+
+Do this on the cluster where you'll be running the controller.
+
+```
+# Create 'Mig' CRDs
+$ oc apply -f config/crds
+
+# Create 'Cluster' CRD
+$ oc apply -f https://raw.githubusercontent.com/kubernetes/cluster-registry/master/cluster-registry-crd.yaml
+```
+
+---
+
+__3.  Use `make run` to run the controller from your terminal.__ 
+
+The controller will connect to OpenShift using your currently active kubeconfig. You may need to run `oc login` first.
+
+```
+$ make run
+
+go generate ./pkg/... ./cmd/...
+go fmt ./pkg/... ./cmd/...
+go vet ./pkg/... ./cmd/...
+go run ./cmd/manager/main.go
+{"level":"info","ts":1555619492,"logger":"entrypoint","msg":"setting up client for manager"}
+{"level":"info","ts":1555619492,"logger":"entrypoint","msg":"setting up manager"}
+{"level":"info","ts":1555619493,"logger":"entrypoint","msg":"Registering Components."}
+
+[...]
+```
+
+## Familiarizing with `make` targets
+
+There are several useful Makefile targets for mig-controller that developers should be aware of.
+
+| Command | Description |
+| --- | --- |
+| `make run` | Build a controller manager binary and run the controller against the active cluster |
+| `make manager` | Build a controller manager binary |
+| `make install` | Install generated CRDs onto the active cluster |
+| `make manifests` | Generate updated CRDs from types.go files, RBAC from annotations in controller, deploy manifest YAML |
+| `make samples` | Copy annotated sample CR contents from config/samples to migsamples, which is .gitignored and safe to keep data in |
+| `make docker-build` | Build the controller-manager into a container image. Requires support for multi-stage builds, which may require moby-engine |

--- a/HACKING.md
+++ b/HACKING.md
@@ -3,7 +3,12 @@
 ## Building and running mig-controller with `make run`
 
 __1. Install prerequisites__
-https://github.com/fusor/mig-controller#prerequisites
+
+ - golang compiler (tested @ 1.11.5)
+ - kubebuilder (tested @ 1.0.7)
+ - dep (tested @ v0.5.0)
+ - velero (tested @ v0.11.0) installed on both clusters involved in migration
+
 
 __2. Create required CRDs (MigMigration, MigPlan, MigCluster, Cluster...)__
 

--- a/README.md
+++ b/README.md
@@ -11,43 +11,59 @@
 
 ## Quick-start
 
-__1. Create required CRDs (MigMigration, MigPlan, MigCluster, Cluster...)__
+__1. Identify a pair of running OpenShift clusters to migrate workloads between__
 
-Do this on the cluster where you'll be running the controller.
+You'll be able to use mig-controller and mig-ui to move workloads from a _source_ to a _destination_ cluster. You'll need cluster-admin permissions on both clusters.
+
+---
+
+__2. Deploy Velero to both the _source_ and _destination_ OpenShift clusters__
 
 ```
-# Create 'Mig' CRDs
-$ oc apply -f config/crds
 
-# Create 'Cluster' CRD
-$ oc apply -f https://raw.githubusercontent.com/kubernetes/cluster-registry/master/cluster-registry-crd.yaml
+# Download bash script to deploy Velero along with required plugins
+$ wget https://github.com/fusor/mig-controller/blob/master/hack/deploy/deploy_velero.sh
+
+# Login to source cluster, run deploy_velero.sh against it
+$ oc login https://my-source-cluster:8443
+$ bash deploy_velero.sh
+
+Deploying Velero...
+[...]
+
+# Login to destination cluster, run deploy_velero.sh against it
+$ oc login https://my-destination-cluster:8443
+$ bash deploy_velero.sh
+
+Deploying Velero...
+[...]
 ```
 
 ---
 
-__2.  Use `make run` to run the controller from your terminal.__ 
-
-The controller will connect to OpenShift using your currently active kubeconfig. You may need to run `oc login` first.
+__2. Deploy _mig-controller_ and _mig-ui_ to one of the two involved clusters__
 
 ```
-$ make run
+# Download bash script to deploy latest mig-controller and mig-ui images
+wget https://github.com/fusor/mig-controller/blob/master/hack/deploy/deploy_mig.sh
 
-go generate ./pkg/... ./cmd/...
-go fmt ./pkg/... ./cmd/...
-go vet ./pkg/... ./cmd/...
-go run ./cmd/manager/main.go
-{"level":"info","ts":1555619492,"logger":"entrypoint","msg":"setting up client for manager"}
-{"level":"info","ts":1555619492,"logger":"entrypoint","msg":"setting up manager"}
-{"level":"info","ts":1555619493,"logger":"entrypoint","msg":"Registering Components."}
+# Login to cluster of your choice where controller + UI will run
+oc login https://my-cluster:8443
+bash deploy_mig.sh
 
+Deploying mig-controller...
 [...]
+
+Deploying mig-ui...
+[...]
+
 ```
 
 ---
 
 __3. Create Mig CRs to describe the Migration that will be performed__
 
-Before mig-controller can run a Migration, you'll need to provide:
+Before mig-controller can run a Migration, you'll need to provide it with:
  - Coordinates & auth info for 2 OpenShift clusters (source + destination)
  - A list of namespaces to be migrated
  - Storage to use for the migration
@@ -57,17 +73,22 @@ Before mig-controller can run a Migration, you'll need to provide:
 - [MigPlan](https://github.com/fusor/mig-controller/blob/master/pkg/apis/migration/v1alpha1/migplan_types.go)
 - [MigCluster](https://github.com/fusor/mig-controller/blob/master/pkg/apis/migration/v1alpha1/migcluster_types.go)
 - [MigStorage](https://github.com/fusor/mig-controller/blob/master/pkg/apis/migration/v1alpha1/migstorage_types.go)
-- [MigStage](https://github.com/fusor/mig-controller/blob/master/pkg/apis/migration/v1alpha1/migstage_types.go)
 - [MigMigration](https://github.com/fusor/mig-controller/blob/master/pkg/apis/migration/v1alpha1/migmigration_types.go)
 - [Cluster](https://github.com/kubernetes/cluster-registry/blob/master/pkg/apis/clusterregistry/v1alpha1/types.go)
 
+
+*__To make it easier to run your first Migration with mig-controller__*, we've published a set of annotated sample CRs that you can walk through and fill out values on. The first step will be to run `make samples`.
 
 ```
 make samples
 # [... sample CR content will be copied to 'migsamples' dir]
 ```
 
-Inspect and edit each of the files in the 'migsamples' directory, making changes as needed.
+**_Inspect and edit each of the files in the 'migsamples' directory, making changes as needed._** Much of the content in these sample files can stay unchanged, but you'll need to provide information such as:
+ 
+ - Remote cluster URL (in the `Cluster` resource)
+ - S3 bucket coordinates and access/secret key
+ - List of namespaces to be migrated from the source to the destination cluster
 
 After modifying resource yaml, create the resources on the OpenShift cluster where the controller is running.
 
@@ -94,14 +115,8 @@ oc apply -f mig-cluster-aws.yaml
 oc apply -f mig-storage-creds.yaml
 oc apply -f mig-storage.yaml
 
-# Describes which resources should be Migrated
-oc apply -f mig-assets.yaml
-
 # Describes which clusters, storage, and namespaces should be to run a Migration
 oc apply -f mig-plan.yaml
-
-# Declares that a Stage operation should be run
-oc apply -f mig-stage.yaml
 
 # Declares that a Migration operation should be run 
 oc apply -f mig-migration.yaml

--- a/README.md
+++ b/README.md
@@ -84,11 +84,20 @@ make samples
 # [... sample CR content will be copied to 'migsamples' dir]
 ```
 
-**_Inspect and edit each of the files in the 'migsamples' directory, making changes as needed._** Much of the content in these sample files can stay unchanged, but you'll need to provide information such as:
- 
- - Remote cluster URL (in the `Cluster` resource)
- - S3 bucket coordinates and access/secret key
- - List of namespaces to be migrated from the source to the destination cluster
+**_Inspect and edit each of the files in the 'migsamples' directory, making changes as needed._** Much of the content in these sample files can stay unchanged. 
+
+As an example, you'll need to provide the following parameters to perform a Migration using an AWS S3 bucket as temporary migration storage:
+
+| Description | Param Name | Purpose | Sample CR File |
+| --- | --- | --- | --- |
+| Namespaces | `namespaces` | List of namespaces to migrate from source to destination cluster | `mig-plan.yaml` |
+| Remote OpenShift URL | `serverAddress` | Endpoint of remote cluster mig-controller will connect to | `cluster-aws.yaml` | 
+| Service Account Token | `saToken` | Base64 encoded SA token used to authenticate with remote cluster | `sa-secret-aws.yaml` | 
+| S3 Bucket Name | `awsBucketName` | Name of the S3 bucket to be used for temporary Migration storage | `mig-storage.yaml` |
+| S3 Bucket Region | `awsRegion` | Region of S3 bucket to be used for temporary Migration storage | `mig-storage.yaml` |
+| AWS Access Key | `aws-access-key-id` | AWS access key to auth with AWS services | `mig-storage-creds.yaml` |
+| AWS Secret Key | `aws-secret-access-key` | AWS secret access key to auth with AWS services | `mig-storage-creds.yaml` |
+
 
 After modifying resource yaml, create the resources on the OpenShift cluster where the controller is running.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,5 @@
 # mig-controller
 
-## Prerequisites
-
- - golang compiler (tested @ 1.11.5)
- - kubebuilder (tested @ 1.0.7)
- - dep (tested @ v0.5.0)
- - velero (tested @ v0.11.0) installed on both clusters involved in migration
-
----
-
 ## Quick-start
 
 __1. Identify a pair of running OpenShift clusters to migrate workloads between__
@@ -41,15 +32,15 @@ Deploying Velero...
 
 ---
 
-__2. Deploy _mig-controller_ and _mig-ui_ to one of the two involved clusters__
+__3. Deploy _mig-controller_ and _mig-ui_ to one of the two involved clusters__
 
 ```
 # Download bash script to deploy latest mig-controller and mig-ui images
-wget https://github.com/fusor/mig-controller/blob/master/hack/deploy/deploy_mig.sh
+$ wget https://github.com/fusor/mig-controller/blob/master/hack/deploy/deploy_mig.sh
 
 # Login to cluster of your choice where controller + UI will run
-oc login https://my-cluster:8443
-bash deploy_mig.sh
+$ oc login https://my-cluster:8443
+$ bash deploy_mig.sh
 
 Deploying mig-controller...
 [...]


### PR DESCRIPTION
 - Focused front-page README.md on new users, add instructions for using deploy bash scripts
 - Add HACKING.md with instructions for developers

 - Add table in README.md describing each param that needs to be modified in `migsamples` to get a basic migration running
 - Add table in HACKING.md describing different `make` targets