### PR TITLE
Add remaining remote watch predicates.

### DIFF
--- a/pkg/controller/remotewatcher/predicate.go
+++ b/pkg/controller/remotewatcher/predicate.go
@@ -2,20 +2,41 @@ package remotewatcher
 
 import (
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
+	velero "github.com/heptio/velero/pkg/apis/velero/v1"
 	kapi "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+func hasCorrelationLabel(labels map[string]string) bool {
+	for label := range labels {
+		_, found := migapi.KnownLabels[label]
+		if found {
+			return true
+		}
+	}
+	return false
+}
+
+// Secret
 type SecretPredicate struct {
 	predicate.Funcs
+}
+
+// Watched resource has been created.
+func (r SecretPredicate) Create(e event.CreateEvent) bool {
+	secret, cast := e.Object.(*kapi.Secret)
+	if cast {
+		return hasCorrelationLabel(secret.Labels)
+	}
+	return false
 }
 
 // Watched resource has been updated.
 func (r SecretPredicate) Update(e event.UpdateEvent) bool {
 	secret, cast := e.ObjectOld.(*kapi.Secret)
 	if cast {
-		return hasCorrelationLabel(secret)
+		return hasCorrelationLabel(secret.Labels)
 	}
 	return false
 }
@@ -24,18 +45,135 @@ func (r SecretPredicate) Update(e event.UpdateEvent) bool {
 func (r SecretPredicate) Delete(e event.DeleteEvent) bool {
 	secret, cast := e.Object.(*kapi.Secret)
 	if cast {
-		return hasCorrelationLabel(secret)
+		return hasCorrelationLabel(secret.Labels)
 	}
 	return false
 }
 
-// The watched object has a correlation label.
-func hasCorrelationLabel(secret *kapi.Secret) bool {
-	for label := range secret.Labels {
-		_, found := migapi.KnownLabels[label]
-		if found {
-			return true
-		}
+// Backup
+type BackupPredicate struct {
+	predicate.Funcs
+}
+
+// Watched resource has been created.
+func (r BackupPredicate) Create(e event.CreateEvent) bool {
+	backup, cast := e.Object.(*velero.Backup)
+	if cast {
+		return hasCorrelationLabel(backup.Labels)
+	}
+	return false
+}
+
+// Watched resource has been updated.
+func (r BackupPredicate) Update(e event.UpdateEvent) bool {
+	backup, cast := e.ObjectOld.(*velero.Backup)
+	if cast {
+		return hasCorrelationLabel(backup.Labels)
+	}
+	return false
+}
+
+// Watched resource has been deleted.
+func (r BackupPredicate) Delete(e event.DeleteEvent) bool {
+	backup, cast := e.Object.(*velero.Backup)
+	if cast {
+		return hasCorrelationLabel(backup.Labels)
+	}
+	return false
+}
+
+// Restore
+type RestorePredicate struct {
+	predicate.Funcs
+}
+
+// Watched resource has been created.
+func (r RestorePredicate) Create(e event.CreateEvent) bool {
+	restore, cast := e.Object.(*velero.Restore)
+	if cast {
+		return hasCorrelationLabel(restore.Labels)
+	}
+	return false
+}
+
+// Watched resource has been updated.
+func (r RestorePredicate) Update(e event.UpdateEvent) bool {
+	restore, cast := e.ObjectOld.(*velero.Restore)
+	if cast {
+		return hasCorrelationLabel(restore.Labels)
+	}
+	return false
+}
+
+// Watched resource has been deleted.
+func (r RestorePredicate) Delete(e event.DeleteEvent) bool {
+	restore, cast := e.Object.(*velero.Restore)
+	if cast {
+		return hasCorrelationLabel(restore.Labels)
+	}
+	return false
+}
+
+// BSL
+type BSLPredicate struct {
+	predicate.Funcs
+}
+
+// Watched resource has been created.
+func (r BSLPredicate) Create(e event.CreateEvent) bool {
+	bsl, cast := e.Object.(*velero.BackupStorageLocation)
+	if cast {
+		return hasCorrelationLabel(bsl.Labels)
+	}
+	return false
+}
+
+// Watched resource has been updated.
+func (r BSLPredicate) Update(e event.UpdateEvent) bool {
+	bsl, cast := e.ObjectOld.(*velero.BackupStorageLocation)
+	if cast {
+		return hasCorrelationLabel(bsl.Labels)
+	}
+	return false
+}
+
+// Watched resource has been deleted.
+func (r BSLPredicate) Delete(e event.DeleteEvent) bool {
+	bsl, cast := e.Object.(*velero.BackupStorageLocation)
+	if cast {
+		return hasCorrelationLabel(bsl.Labels)
+	}
+	return false
+}
+
+// VSL
+type VSLPredicate struct {
+	predicate.Funcs
+}
+
+// Watched resource has been created.
+func (r VSLPredicate) Create(e event.CreateEvent) bool {
+	vsl, cast := e.Object.(*velero.VolumeSnapshotLocation)
+	if cast {
+		return hasCorrelationLabel(vsl.Labels)
+	}
+	return false
+}
+
+// Watched resource has been updated.
+func (r VSLPredicate) Update(e event.UpdateEvent) bool {
+	vsl, cast := e.ObjectOld.(*velero.VolumeSnapshotLocation)
+	if cast {
+		return hasCorrelationLabel(vsl.Labels)
+	}
+	return false
+}
+
+// Watched resource has been deleted.
+func (r VSLPredicate) Delete(e event.DeleteEvent) bool {
+	vsl, cast := e.Object.(*velero.VolumeSnapshotLocation)
+	if cast {
+		return hasCorrelationLabel(vsl.Labels)
 	}
 	return false
 }

--- a/pkg/controller/remotewatcher/remotewatcher_controller.go
+++ b/pkg/controller/remotewatcher/remotewatcher_controller.go
@@ -45,26 +45,62 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	if err != nil {
 		return err
 	}
-	err = c.Watch(&source.Kind{Type: &velerov1.Backup{}}, &handler.EnqueueRequestForObject{})
+
+	// Backup
+	err = c.Watch(
+		&source.Kind{
+			Type: &velerov1.Backup{},
+		},
+		&handler.EnqueueRequestForObject{},
+		&BackupPredicate{})
 	if err != nil {
 		return err
 	}
-	err = c.Watch(&source.Kind{Type: &velerov1.Restore{}}, &handler.EnqueueRequestForObject{})
+
+	// Restore
+	err = c.Watch(
+		&source.Kind{
+			Type: &velerov1.Restore{},
+		},
+		&handler.EnqueueRequestForObject{},
+		&RestorePredicate{})
 	if err != nil {
 		return err
 	}
-	err = c.Watch(&source.Kind{Type: &velerov1.BackupStorageLocation{}}, &handler.EnqueueRequestForObject{})
+
+	// BSL
+	err = c.Watch(
+		&source.Kind{
+			Type: &velerov1.BackupStorageLocation{},
+		},
+		&handler.EnqueueRequestForObject{},
+		&BSLPredicate{})
 	if err != nil {
 		return err
 	}
-	err = c.Watch(&source.Kind{Type: &velerov1.VolumeSnapshotLocation{}}, &handler.EnqueueRequestForObject{})
+
+	// VSL
+	err = c.Watch(
+		&source.Kind{
+			Type: &velerov1.VolumeSnapshotLocation{},
+		},
+		&handler.EnqueueRequestForObject{},
+		&VSLPredicate{})
 	if err != nil {
 		return err
 	}
-	err = c.Watch(&source.Kind{Type: &kapi.Secret{}}, &handler.EnqueueRequestForObject{}, &SecretPredicate{})
+
+	// Secret
+	err = c.Watch(
+		&source.Kind{
+			Type: &kapi.Secret{},
+		},
+		&handler.EnqueueRequestForObject{},
+		&SecretPredicate{})
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Limit remote watch events to resources that the controller has created.  This is determined by the existence of our _correlation_ labels.