### PR TITLE
Annotate MigCluster with UUID to avoid stall on OCP4

### DIFF
--- a/pkg/controller/migcluster/migcluster_controller.go
+++ b/pkg/controller/migcluster/migcluster_controller.go
@@ -24,10 +24,12 @@ import (
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
 	"github.com/fusor/mig-controller/pkg/remote"
+	"github.com/google/uuid"
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+
 	crapi "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -129,6 +131,9 @@ func (r *ReconcileMigCluster) Reconcile(request reconcile.Request) (reconcile.Re
 		}
 		return reconcile.Result{}, err // requeue
 	}
+
+	// Annotate with reconcile-unique UUID to trigger MigMigration reconcile
+	migCluster.Annotations["reconcile-id"] = uuid.New().String()
 
 	// Validations.
 	err = r.validate(migCluster)


### PR DESCRIPTION
OCP4 seems to be smarter about not bumping the `resourceVersion` when we don't actually change anything in an `update` call. Event propagation relies on the `resourceVersion`, so to get around this, I've started annotating a reconcile-unique UUID to the MigCluster object. 

This fixes stalled Migration jobs on OCP 4 clusters.