### PR TITLE
Watch namespaces

### DIFF
--- a/pkg/controller/remotewatcher/remotewatcher_controller.go
+++ b/pkg/controller/remotewatcher/remotewatcher_controller.go
@@ -140,6 +140,16 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Namespaces
+	err = c.Watch(
+		&source.Kind{
+			Type: &kapi.Namespace{},
+		},
+		&handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Watch for namespaces to be created or deleted on the source cluster.  This is needed for Plan validation.