### PR TITLE
Add the 'Closed' concept to MigPlan and remove registry for closed plans

### DIFF
--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -35,6 +35,7 @@ type MigPlanSpec struct {
 	SrcMigClusterRef  *kapi.ObjectReference `json:"srcMigClusterRef,omitempty"`
 	DestMigClusterRef *kapi.ObjectReference `json:"destMigClusterRef,omitempty"`
 	MigStorageRef     *kapi.ObjectReference `json:"migStorageRef,omitempty"`
+	Closed            bool                  `json:"closed,omitempty"`
 }
 
 // MigPlanStatus defines the observed state of MigPlan
@@ -132,6 +133,11 @@ func (r *MigPlan) GetRefResources(client k8sclient.Client) (*PlanResources, erro
 	}
 
 	return resources, nil
+}
+
+// Set the MigPlan Status to closed
+func (r *MigPlan) SetClosed() {
+	r.Spec.Closed = true
 }
 
 // Build a credentials Secret as desired for the source cluster.

--- a/pkg/apis/migration/v1alpha1/model.go
+++ b/pkg/apis/migration/v1alpha1/model.go
@@ -29,7 +29,10 @@ func ListPlans(client k8sclient.Client, ns string) ([]MigPlan, error) {
 // Returns and empty list when none found.
 func ListClusters(client k8sclient.Client, ns string) ([]MigCluster, error) {
 	list := MigClusterList{}
-	options := k8sclient.InNamespace(ns)
+	var options *k8sclient.ListOptions
+	if ns != "" {
+		options = k8sclient.InNamespace(ns)
+	}
 	err := client.List(context.TODO(), options, &list)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -105,6 +105,13 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (bool, e
 		if err != nil {
 			return false, err
 		}
+		if !migration.Spec.Stage {
+			plan.SetClosed()
+			err = r.Update(context.TODO(), plan)
+			if err != nil {
+				return false, err
+			}
+		}
 	}
 
 	return false, nil

--- a/pkg/controller/migplan/close.go
+++ b/pkg/controller/migplan/close.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migplan
+
+import (
+	"context"
+
+	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
+)
+
+func (r ReconcileMigPlan) handleClosed(plan *migapi.MigPlan) (bool, error) {
+	closed := plan.Spec.Closed
+	if !closed || plan.Status.HasCondition(Closed) {
+		return closed, nil
+	}
+
+	plan.Status.SetReady(false, ReadyMessage)
+	err := r.Update(context.TODO(), plan)
+	if err != nil {
+		return closed, err
+	}
+
+	err = r.ensureClosed(plan)
+	return closed, err
+}
+
+// Ensure that resources managed by the MigPlan have been cleaned up
+func (r ReconcileMigPlan) ensureClosed(plan *migapi.MigPlan) error {
+	// Migration Registry
+	err := r.ensureMigRegistriesDelete(plan)
+	if err != nil {
+		return err
+	}
+
+	plan.Status.DeleteCondition(RegistriesEnsured)
+	plan.Status.SetCondition(migapi.Condition{
+		Type:     Closed,
+		Status:   True,
+		Category: Critical,
+		Message:  ClosedMessage,
+	})
+	// Apply changes.
+	err = r.Update(context.TODO(), plan)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -127,6 +127,18 @@ func (r *ReconcileMigPlan) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
+	// If plan is closed, ensure resource cleanup
+	closed, err := r.handleClosed(plan)
+	if err != nil {
+		if errors.IsConflict(err) {
+			return reconcile.Result{Requeue: true}, nil
+		}
+		return reconcile.Result{}, err
+	}
+	if closed {
+		return reconcile.Result{}, nil
+	}
+
 	// Validations.
 	err = r.validate(plan)
 	if err != nil {

--- a/pkg/controller/migplan/registry.go
+++ b/pkg/controller/migplan/registry.go
@@ -221,3 +221,116 @@ func (r ReconcileMigPlan) ensureRegistryService(client k8sclient.Client, plan *m
 
 	return nil
 }
+
+// Ensure the migration registries on both source and dest clusters have been removed
+func (r ReconcileMigPlan) ensureMigRegistriesDelete(plan *migapi.MigPlan) error {
+	var client k8sclient.Client
+
+	clusters, err := migapi.ListClusters(r, "")
+	if err != nil {
+		return err
+	}
+
+	for _, cluster := range clusters {
+		if !cluster.Status.IsReady() {
+			continue
+		}
+		client, err = cluster.GetClient(r)
+		if err != nil {
+			return err
+		}
+
+		// Migration Registry Service
+		err = r.ensureRegistryServiceDelete(client, plan)
+		if err != nil {
+			return err
+		}
+
+		// Migration Registry DeploymentConfig
+		err = r.ensureRegistryDCDelete(client, plan)
+		if err != nil {
+			return err
+		}
+		// Migration Registry ImageStream
+		err = r.ensureRegistryImageStreamDelete(client, plan)
+		if err != nil {
+			return err
+		}
+
+		// Migration Registry Secret
+		err := r.ensureRegistrySecretDelete(client, plan)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Ensure the service for the migration registry on the specified cluster has been created
+func (r ReconcileMigPlan) ensureRegistryServiceDelete(client k8sclient.Client, plan *migapi.MigPlan) error {
+	foundService, err := plan.GetRegistryService(client)
+	if err != nil {
+		return err
+	}
+	if foundService == nil {
+		return nil
+	}
+	err = client.Delete(context.TODO(), foundService)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Ensure the deploymentconfig for the migration registry on the specified cluster has been created
+func (r ReconcileMigPlan) ensureRegistryDCDelete(client k8sclient.Client, plan *migapi.MigPlan) error {
+	foundDC, err := plan.GetRegistryDC(client)
+	if err != nil {
+		return err
+	}
+	if foundDC == nil {
+		return nil
+	}
+	err = client.Delete(context.TODO(), foundDC)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Ensure the imagestream for the migration registry on the specified cluster has been created
+func (r ReconcileMigPlan) ensureRegistryImageStreamDelete(client k8sclient.Client, plan *migapi.MigPlan) error {
+	foundImageStream, err := plan.GetRegistryImageStream(client)
+	if err != nil {
+		return err
+	}
+	if foundImageStream == nil {
+		return nil
+	}
+	err = client.Delete(context.TODO(), foundImageStream)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Ensure the credentials secret for the migration registry on the specified cluster has been created
+func (r ReconcileMigPlan) ensureRegistrySecretDelete(client k8sclient.Client, plan *migapi.MigPlan) error {
+	foundSecret, err := plan.GetRegistrySecret(client)
+	if err != nil {
+		return err
+	}
+	if foundSecret == nil {
+		return nil
+	}
+	err = client.Delete(context.TODO(), foundSecret)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -31,6 +31,7 @@ const (
 	StorageEnsured                 = "StorageEnsured"
 	RegistriesEnsured              = "RegistriesEnsured"
 	PvsDiscovered                  = "PvsDiscovered"
+	Closed                         = "Closed"
 )
 
 // Categories
@@ -73,6 +74,7 @@ const (
 	StorageEnsuredMessage                 = "The storage resources have been created."
 	RegistriesEnsuredMessage              = "The migration registry resources have been created."
 	PvsDiscoveredMessage                  = "The `persistentVolumes` list has been updated with discovered PVs."
+	ClosedMessage                         = "The migration plan is closed."
 )
 
 // Validate the plan resource.


### PR DESCRIPTION
When a final migration completes, close the MigPlan.
Upon closing, a MigPlan removes migration registry resources.
Still to do:
1) Clean up storage resources as part of closing as well
2) Figure out how to deal with resource cleanup for clusters
   that are no longer referenced by the MigPlan but have
   registry or storage resources that have matching correlation labels.