### PR TITLE
Allow PV discovery if enough of MigPlan is present

### DIFF
--- a/pkg/apis/migration/v1alpha1/condition.go
+++ b/pkg/apis/migration/v1alpha1/condition.go
@@ -1,8 +1,9 @@
 package v1alpha1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Types

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -136,6 +136,15 @@ func (r *ReconcileMigPlan) Reconcile(request reconcile.Request) (reconcile.Resul
 			return reconcile.Result{}, err
 		}
 	}
+
+	// PV discovery
+	if !r.hasPvDiscoveryBlocker(plan) {
+		err = r.updatePvs(plan)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	if plan.Status.HasCriticalCondition() {
 		plan.Status.SetReady(false, ReadyMessage)
 		err = r.Update(context.TODO(), plan)
@@ -148,12 +157,6 @@ func (r *ReconcileMigPlan) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 		// done
 		return reconcile.Result{}, nil
-	}
-
-	// PV discovery
-	err = r.updatePvs(plan)
-	if err != nil {
-		return reconcile.Result{}, err
 	}
 
 	// Storage

--- a/pkg/controller/migplan/pvlist.go
+++ b/pkg/controller/migplan/pvlist.go
@@ -2,6 +2,7 @@ package migplan
 
 import (
 	"context"
+
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
 	core "k8s.io/api/core/v1"
@@ -14,11 +15,13 @@ type Claims []types.NamespacedName
 
 // Update the PVs listed on the plan.
 func (r *ReconcileMigPlan) updatePvs(plan *migapi.MigPlan) error {
-	planResources, err := plan.GetRefResources(r)
+	// Get srcMigCluster
+	srcMigCluster, err := plan.GetSourceCluster(r.Client)
 	if err != nil {
 		return err
 	}
-	client, err := planResources.SrcMigCluster.GetClient(r)
+
+	client, err := srcMigCluster.GetClient(r)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -3,11 +3,12 @@ package migplan
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
+
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
-	"strings"
 
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
@@ -445,4 +446,14 @@ func (r ReconcileMigPlan) validatePvAction(plan *migapi.MigPlan) error {
 	}
 
 	return nil
+}
+
+// The collection contains a PV discovery blocker condition.
+func (r ReconcileMigPlan) hasPvDiscoveryBlocker(plan *migapi.MigPlan) bool {
+	return plan.Status.HasCondition(
+		InvalidSourceClusterRef,
+		SourceClusterNotReady,
+		NsListEmpty,
+		NsNotFoundOnSourceCluster,
+	)
 }


### PR DESCRIPTION
UI flow has PV actions being filled out before MigStorage is created, this PR aims to allow for PV discovery if the user has supplied enough info in MigPlan, rather than bailing out of PV discovery if the MigPlan is missing _any_ info.