### PR TITLE
Report migration errors.

### DIFF
--- a/config/crds/migration_v1alpha1_migmigration.yaml
+++ b/config/crds/migration_v1alpha1_migmigration.yaml
@@ -30,6 +30,8 @@ spec:
           properties:
             migPlanRef:
               type: object
+            quiescePods:
+              type: boolean
             stage:
               type: boolean
           required:
@@ -40,14 +42,18 @@ spec:
             completionTimestamp:
               format: date-time
               type: string
+            errors:
+              items:
+                type: string
+              type: array
             migrationCompleted:
               type: boolean
             migrationStarted:
               type: boolean
+            phase:
+              type: string
             startTimestamp:
               format: date-time
-              type: string
-            taskPhase:
               type: string
           type: object
   version: v1alpha1

--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -41,7 +41,8 @@ type MigMigrationStatus struct {
 	MigrationCompleted  bool         `json:"migrationCompleted,omitempty"`
 	StartTimestamp      *metav1.Time `json:"startTimestamp,omitempty"`
 	CompletionTimestamp *metav1.Time `json:"completionTimestamp,omitempty"`
-	TaskPhase           string       `json:"taskPhase,omitempty"`
+	Phase               string       `json:"phase,omitempty"`
+	Errors              []string     `json:"errors,omitempty"`
 }
 
 // +genclient
@@ -101,4 +102,18 @@ func (r *MigMigration) MarkAsCompleted() bool {
 // Get whether the migration has completed.
 func (r *MigMigration) IsCompleted() bool {
 	return r.Status.MigrationCompleted
+}
+
+// Add (de-duplicated) errors.
+func (r *MigMigration) AddErrors(errors []string) {
+	m := map[string]bool{}
+	for _, e := range r.Status.Errors {
+		m[e] = true
+	}
+	for _, error := range errors {
+		_, found := m[error]
+		if !found {
+			r.Status.Errors = append(r.Status.Errors, error)
+		}
+	}
 }

--- a/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
@@ -283,6 +283,11 @@ func (in *MigMigrationStatus) DeepCopyInto(out *MigMigrationStatus) {
 		in, out := &in.CompletionTimestamp, &out.CompletionTimestamp
 		*out = (*in).DeepCopy()
 	}
+	if in.Errors != nil {
+		in, out := &in.Errors, &out.Errors
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Initial pass to report available velero failure information.  In future iterations - more detail can be provided by mining the velero pod log or information velero stashes in the cloud.

Add `Errors` array to describe errors reported by velero.  For validation errors, the velero `ValidationErrors` will be propagated.  Otherwise, an error will be added that either the backup or restore failed including the namespaced name.

Rename: `TaskPhase` to `Phase`.  We were _on the fence_ about this but I think it provides useful troubleshooting information and thinking this _tips the scales_.

The UI or CLI user can determine failure by:
- Errors is not nil (or empty).
- The phase will be `BackupFailed` or `RestoreFailed`.
- The phase is not `Complete` and `MigrationCompleted` is _true_.

For now, the user will need to troubleshoot by reviewing the pod logs.