### PR TITLE
Use fusor-dev for plugin img tag

### DIFF
--- a/hack/deploy/manifests/20-velero-deployment.yaml
+++ b/hack/deploy/manifests/20-velero-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: velero
       containers:
         - name: velero
-          image: quay.io/ocpmigrate/velero:latest
+          image: quay.io/ocpmigrate/velero:fusor-dev
           imagePullPolicy: Always
           ports:
             - name: metrics

--- a/hack/deploy/manifests/30-restic-daemonset.yaml
+++ b/hack/deploy/manifests/30-restic-daemonset.yaml
@@ -40,7 +40,7 @@ spec:
           emptyDir: {}
       containers:
         - name: velero
-          image: quay.io/ocpmigrate/velero:latest
+          image: quay.io/ocpmigrate/velero:fusor-dev
           command:
             - /velero
           args:


### PR DESCRIPTION
@dymurray ~~should the main velero image also use `fusor-dev`? I haven't tested with that, but I notice it has a different sha than latest in quay.~~

Realized I screwed this up; there isn't a fusor-dev tag for the plugin, but we should be using the fusor-dev tag for the main velero img?