### PR TITLE
Atomic update of conditions to prevent oscillation.

### DIFF
--- a/pkg/apis/migration/v1alpha1/condition.go
+++ b/pkg/apis/migration/v1alpha1/condition.go
@@ -158,8 +158,13 @@ func (r *Conditions) DeleteCondition(types ...string) {
 	kept := []Condition{}
 	for i := range r.List {
 		condition := r.List[i]
-		_, found := filter[condition.Type]
-		if !found {
+		_, matched := filter[condition.Type]
+		if !matched {
+			kept = append(kept, condition)
+			continue
+		}
+		if r.staging {
+			condition.staged = false
 			kept = append(kept, condition)
 		}
 	}
@@ -182,6 +187,25 @@ func (r *Conditions) HasCondition(types ...string) bool {
 	}
 
 	return len(types) > 0
+}
+
+// The collection has Any of the specified conditions.
+func (r *Conditions) HasAnyCondition(types ...string) bool {
+	if r.List == nil {
+		return false
+	}
+	for _, cndType := range types {
+		condition := r.FindCondition(cndType)
+		if condition == nil || condition.Status != True {
+			continue
+		}
+		if r.staging && !condition.staged {
+			continue
+		}
+		return true
+	}
+
+	return false
 }
 
 // The collection contains any conditions with category.

--- a/pkg/apis/migration/v1alpha1/condition_test.go
+++ b/pkg/apis/migration/v1alpha1/condition_test.go
@@ -193,7 +193,55 @@ func TestConditions_DeleteCondition(t *testing.T) {
 	}))
 }
 
+func TestConditions_DeleteConditionStaging(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// Setup
+	conditions := Conditions{
+		List: []Condition{
+			{Type: "A"},
+			{Type: "B"},
+			{Type: "C"},
+			{Type: "D"},
+			{Type: "E"},
+		},
+	}
+
+	// Test
+	conditions.BeginStagingConditions()
+	conditions.DeleteCondition("B", "D")
+
+	// Validation
+	g.Expect(conditions.List).To(gomega.Equal([]Condition{
+		{Type: "A"},
+		{Type: "B", staged: false},
+		{Type: "C"},
+		{Type: "D", staged: false},
+		{Type: "E"},
+	}))
+}
+
 func TestConditions_HasCondition(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// Setup
+	conditions := Conditions{
+		List: []Condition{
+			{Type: "A", Status: True},
+			{Type: "B", Status: False},
+			{Type: "C", Status: True},
+		},
+	}
+
+	// Test Found Status: True
+	g.Expect(conditions.HasCondition("A", "C")).To(gomega.BeTrue())
+	// Test NotFound
+	g.Expect(conditions.HasCondition("X")).To(gomega.BeFalse())
+	// Test Status: not-True
+	g.Expect(conditions.HasCondition("B")).To(gomega.BeFalse())
+}
+
+func TestConditions_HasAnyCondition(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	// Setup
@@ -205,11 +253,7 @@ func TestConditions_HasCondition(t *testing.T) {
 	}
 
 	// Test Found Status: True
-	g.Expect(conditions.HasCondition("A")).To(gomega.BeTrue())
-	// Test NotFound
-	g.Expect(conditions.HasCondition("X")).To(gomega.BeFalse())
-	// Test Status: not-True
-	g.Expect(conditions.HasCondition("B")).To(gomega.BeFalse())
+	g.Expect(conditions.HasAnyCondition("A", "B")).To(gomega.BeTrue())
 }
 
 func TestConditions_HasConditionStaging(t *testing.T) {

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"reflect"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sort"
 )
 
 // MigPlanSpec defines the desired state of MigPlan
@@ -550,6 +551,7 @@ func (r *PersistentVolumes) BeginPvStaging() {
 }
 
 // End staging PVs and delete un-staged PVs from the list.
+// The PVs are sorted by Name.
 func (r *PersistentVolumes) EndPvStaging() {
 	r.init()
 	r.staging = false
@@ -559,6 +561,11 @@ func (r *PersistentVolumes) EndPvStaging() {
 			kept = append(kept, pv)
 		}
 	}
+	sort.Slice(
+		kept,
+		func(i, j int) bool {
+			return kept[i].Name < kept[j].Name
+		})
 	r.List = kept
 	r.buildIndex()
 }

--- a/pkg/apis/migration/v1alpha1/resource.go
+++ b/pkg/apis/migration/v1alpha1/resource.go
@@ -1,10 +1,30 @@
 package v1alpha1
 
+import (
+	"github.com/google/uuid"
+)
+
+const (
+	TouchAnnotation = "touch"
+)
+
 // Migration application CR.
+// The `touch` UUID is set by the controller after reconcile
+// and needed to support relay of remote watch events. Also to
+// provide remote watch predicates the ability to determine
+// when an updated referenced resource has been fully reconciled.
 type MigResource interface {
+	// Get the correlation labels.
+	// Labels are used as a back-reference to this resource.
 	GetCorrelationLabels() map[string]string
+	// Get the resource namespace.
 	GetNamespace() string
+	// Get the resource name.
 	GetName() string
+	// Get the `touch` UUID annotation.
+	GetTouch() string
+	// Set the `touch` UUID annotation.
+	Touch()
 }
 
 // Plan
@@ -20,6 +40,25 @@ func (r *MigPlan) GetName() string {
 	return r.Name
 }
 
+func (r *MigPlan) GetTouch() string {
+	if r.Annotations == nil {
+		return ""
+	}
+	id, found := r.Annotations[TouchAnnotation]
+	if found {
+		return id
+	}
+
+	return ""
+}
+
+func (r *MigPlan) Touch() {
+	if r.Annotations == nil {
+		r.Annotations = make(map[string]string)
+	}
+	r.Annotations[TouchAnnotation] = uuid.New().String()
+}
+
 // Storage
 func (r *MigStorage) GetCorrelationLabels() map[string]string {
 	return buildCorrelationLabels(r, r.UID)
@@ -31,6 +70,25 @@ func (r *MigStorage) GetNamespace() string {
 
 func (r *MigStorage) GetName() string {
 	return r.Name
+}
+
+func (r *MigStorage) GetTouch() string {
+	if r.Annotations == nil {
+		return ""
+	}
+	id, found := r.Annotations[TouchAnnotation]
+	if found {
+		return id
+	}
+
+	return ""
+}
+
+func (r *MigStorage) Touch() {
+	if r.Annotations == nil {
+		r.Annotations = make(map[string]string)
+	}
+	r.Annotations[TouchAnnotation] = uuid.New().String()
 }
 
 // Cluster
@@ -46,6 +104,25 @@ func (r *MigCluster) GetName() string {
 	return r.Name
 }
 
+func (r *MigCluster) GetTouch() string {
+	if r.Annotations == nil {
+		return ""
+	}
+	id, found := r.Annotations[TouchAnnotation]
+	if found {
+		return id
+	}
+
+	return ""
+}
+
+func (r *MigCluster) Touch() {
+	if r.Annotations == nil {
+		r.Annotations = make(map[string]string)
+	}
+	r.Annotations[TouchAnnotation] = uuid.New().String()
+}
+
 // Migration
 func (r *MigMigration) GetCorrelationLabels() map[string]string {
 	return buildCorrelationLabels(r, r.UID)
@@ -57,4 +134,23 @@ func (r *MigMigration) GetNamespace() string {
 
 func (r *MigMigration) GetName() string {
 	return r.Name
+}
+
+func (r *MigMigration) GetTouch() string {
+	if r.Annotations == nil {
+		return ""
+	}
+	id, found := r.Annotations[TouchAnnotation]
+	if found {
+		return id
+	}
+
+	return ""
+}
+
+func (r *MigMigration) Touch() {
+	if r.Annotations == nil {
+		r.Annotations = make(map[string]string)
+	}
+	r.Annotations[TouchAnnotation] = uuid.New().String()
 }

--- a/pkg/controller/migcluster/validation.go
+++ b/pkg/controller/migcluster/validation.go
@@ -49,8 +49,6 @@ const (
 // Validate the asset collection resource.
 // Returns error and the total error conditions set.
 func (r ReconcileMigCluster) validate(cluster *migapi.MigCluster) error {
-	cluster.Status.BeginStagingConditions()
-
 	// registry cluster
 	err := r.validateRegistryCluster(cluster)
 	if err != nil {
@@ -65,18 +63,6 @@ func (r ReconcileMigCluster) validate(cluster *migapi.MigCluster) error {
 
 	// Test Connection
 	err = r.testConnection(cluster)
-	if err != nil {
-		return err
-	}
-
-	// Ready
-	cluster.Status.SetReady(
-		!cluster.Status.HasBlockerCondition(),
-		ReadyMessage)
-
-	// Apply changes.
-	cluster.Status.EndStagingConditions()
-	err = r.Update(context.TODO(), cluster)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -162,11 +162,11 @@ func (t *Task) updateBackup(backup *velero.Backup) error {
 	backup.Spec = velero.BackupSpec{
 		StorageLocation:         backupLocation.Name,
 		VolumeSnapshotLocations: []string{snapshotLocation.Name},
-		TTL:                metav1.Duration{Duration: 720 * time.Hour},
-		IncludedNamespaces: namespaces,
-		ExcludedNamespaces: []string{},
-		IncludedResources:  t.BackupResources,
-		ExcludedResources:  []string{},
+		TTL:                     metav1.Duration{Duration: 720 * time.Hour},
+		IncludedNamespaces:      namespaces,
+		ExcludedNamespaces:      []string{},
+		IncludedResources:       t.BackupResources,
+		ExcludedResources:       []string{},
 		Hooks: velero.BackupHooks{
 			Resources: []velero.BackupResourceHookSpec{},
 		},

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -68,10 +68,6 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (bool, e
 	// Started
 	if !migration.Status.MigrationRunning {
 		migration.MarkAsRunning()
-		err = r.Update(context.TODO(), migration)
-		if err != nil {
-			return false, err
-		}
 	}
 
 	// Run
@@ -93,26 +89,14 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (bool, e
 		return false, err
 	}
 	migration.Status.Phase = task.Phase
-	err = r.Update(context.TODO(), migration)
-	if err != nil {
-		return false, err
-	}
 	switch task.Phase {
 	case WaitOnResticRestart:
 		return true, nil
 	case BackupFailed, RestoreFailed:
 		migration.MarkAsCompleted()
 		migration.AddErrors(task.Errors)
-		err = r.Update(context.TODO(), migration)
-		if err != nil {
-			return false, err
-		}
 	case Completed:
 		migration.MarkAsCompleted()
-		err = r.Update(context.TODO(), migration)
-		if err != nil {
-			return false, err
-		}
 		if !migration.Spec.Stage {
 			plan.SetClosed()
 			err = r.Update(context.TODO(), plan)

--- a/pkg/controller/migmigration/predicate.go
+++ b/pkg/controller/migmigration/predicate.go
@@ -84,3 +84,25 @@ func (r MigrationPredicate) unmapRefs(migration *migapi.MigMigration) {
 		})
 	}
 }
+
+type PlanPredicate struct {
+	predicate.Funcs
+}
+
+func (r PlanPredicate) Create(e event.CreateEvent) bool {
+	return false
+}
+
+func (r PlanPredicate) Update(e event.UpdateEvent) bool {
+	old, cast := e.ObjectOld.(*migapi.MigPlan)
+	if !cast {
+		return false
+	}
+	new, cast := e.ObjectNew.(*migapi.MigPlan)
+	if !cast {
+		return false
+	}
+	// Updated by the controller.
+	touched := old.GetTouch() != new.GetTouch()
+	return touched
+}

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -1,8 +1,6 @@
 package migmigration
 
 import (
-	"context"
-
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
 )
@@ -40,22 +38,8 @@ const (
 // Validate the plan resource.
 // Returns error and the total error conditions set.
 func (r ReconcileMigMigration) validate(migration *migapi.MigMigration) error {
-	migration.Status.BeginStagingConditions()
-
 	// Plan
 	err := r.validatePlan(migration)
-	if err != nil {
-		return err
-	}
-
-	// Ready
-	migration.Status.SetReady(
-		!migration.Status.HasBlockerCondition(),
-		ReadyMessage)
-
-	// Apply changes.
-	migration.Status.EndStagingConditions()
-	err = r.Update(context.TODO(), migration)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/migplan/close.go
+++ b/pkg/controller/migplan/close.go
@@ -28,6 +28,7 @@ func (r ReconcileMigPlan) handleClosed(plan *migapi.MigPlan) (bool, error) {
 		return closed, nil
 	}
 
+	plan.Touch()
 	plan.Status.SetReady(false, ReadyMessage)
 	err := r.Update(context.TODO(), plan)
 	if err != nil {
@@ -54,6 +55,7 @@ func (r ReconcileMigPlan) ensureClosed(plan *migapi.MigPlan) error {
 		Message:  ClosedMessage,
 	})
 	// Apply changes.
+	plan.Touch()
 	err = r.Update(context.TODO(), plan)
 	if err != nil {
 		return err

--- a/pkg/controller/migplan/predicate.go
+++ b/pkg/controller/migplan/predicate.go
@@ -124,3 +124,47 @@ func (r PlanPredicate) unmapRefs(plan *migapi.MigPlan) {
 		})
 	}
 }
+
+type ClusterPredicate struct {
+	predicate.Funcs
+}
+
+func (r ClusterPredicate) Create(e event.CreateEvent) bool {
+	return false
+}
+
+func (r ClusterPredicate) Update(e event.UpdateEvent) bool {
+	old, cast := e.ObjectOld.(*migapi.MigCluster)
+	if !cast {
+		return false
+	}
+	new, cast := e.ObjectNew.(*migapi.MigCluster)
+	if !cast {
+		return false
+	}
+	// Updated by the controller.
+	touched := old.GetTouch() != new.GetTouch()
+	return touched
+}
+
+type StoragePredicate struct {
+	predicate.Funcs
+}
+
+func (r StoragePredicate) Create(e event.CreateEvent) bool {
+	return false
+}
+
+func (r StoragePredicate) Update(e event.UpdateEvent) bool {
+	old, cast := e.ObjectOld.(*migapi.MigStorage)
+	if !cast {
+		return false
+	}
+	new, cast := e.ObjectNew.(*migapi.MigStorage)
+	if !cast {
+		return false
+	}
+	// Updated by the controller.
+	touched := old.GetTouch() != new.GetTouch()
+	return touched
+}

--- a/pkg/controller/migplan/pvlist.go
+++ b/pkg/controller/migplan/pvlist.go
@@ -15,6 +15,14 @@ type Claims []types.NamespacedName
 
 // Update the PVs listed on the plan.
 func (r *ReconcileMigPlan) updatePvs(plan *migapi.MigPlan) error {
+	if plan.Status.HasAnyCondition(
+		InvalidSourceClusterRef,
+		SourceClusterNotReady,
+		NsListEmpty,
+		NsNotFoundOnSourceCluster) {
+		return nil
+	}
+
 	// Get srcMigCluster
 	srcMigCluster, err := plan.GetSourceCluster(r.Client)
 	if err != nil {
@@ -60,12 +68,7 @@ func (r *ReconcileMigPlan) updatePvs(plan *migapi.MigPlan) error {
 		Message:  PvsDiscoveredMessage,
 	})
 
-	// Update
 	plan.Spec.PersistentVolumes.EndPvStaging()
-	err = r.Update(context.TODO(), plan)
-	if err != nil {
-		return nil
-	}
 
 	return nil
 }

--- a/pkg/controller/migplan/registry.go
+++ b/pkg/controller/migplan/registry.go
@@ -70,12 +70,6 @@ func (r ReconcileMigPlan) ensureMigRegistries(plan *migapi.MigPlan) error {
 			Category: migapi.Required,
 			Message:  RegistriesEnsuredMessage,
 		})
-	} else {
-		plan.Status.DeleteCondition(RegistriesEnsured)
-	}
-	err = r.Update(context.TODO(), plan)
-	if err != nil {
-		return err
 	}
 
 	return err

--- a/pkg/controller/migplan/storage.go
+++ b/pkg/controller/migplan/storage.go
@@ -63,12 +63,6 @@ func (r ReconcileMigPlan) ensureStorage(plan *migapi.MigPlan) error {
 			Category: migapi.Required,
 			Message:  StorageEnsuredMessage,
 		})
-	} else {
-		plan.Status.DeleteCondition(StorageEnsured)
-	}
-	err = r.Update(context.TODO(), plan)
-	if err != nil {
-		return err
 	}
 
 	return err

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -79,8 +79,6 @@ const (
 
 // Validate the plan resource.
 func (r ReconcileMigPlan) validate(plan *migapi.MigPlan) error {
-	plan.Status.BeginStagingConditions()
-
 	// Source cluster
 	err := r.validateSourceCluster(plan)
 	if err != nil {
@@ -107,19 +105,6 @@ func (r ReconcileMigPlan) validate(plan *migapi.MigPlan) error {
 
 	// Required namespaces.
 	err = r.validateRequiredNamespaces(plan)
-	if err != nil {
-		return err
-	}
-
-	// PV list.
-	err = r.validatePvAction(plan)
-	if err != nil {
-		return err
-	}
-
-	// Apply changes.
-	plan.Status.EndStagingConditions()
-	err = r.Update(context.TODO(), plan)
 	if err != nil {
 		return err
 	}
@@ -448,14 +433,4 @@ func (r ReconcileMigPlan) validatePvAction(plan *migapi.MigPlan) error {
 	}
 
 	return nil
-}
-
-// The collection contains a PV discovery blocker condition.
-func (r ReconcileMigPlan) hasPvDiscoveryBlocker(plan *migapi.MigPlan) bool {
-	return plan.Status.HasCondition(
-		InvalidSourceClusterRef,
-		SourceClusterNotReady,
-		NsListEmpty,
-		NsNotFoundOnSourceCluster,
-	)
 }

--- a/pkg/controller/migstorage/validation.go
+++ b/pkg/controller/migstorage/validation.go
@@ -1,7 +1,6 @@
 package migstorage
 
 import (
-	"context"
 	"fmt"
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
@@ -59,8 +58,6 @@ const (
 
 // Validate the storage resource.
 func (r ReconcileMigStorage) validate(storage *migapi.MigStorage) error {
-	storage.Status.BeginStagingConditions()
-
 	// Backup location provider.
 	err := r.validateBSL(storage)
 	if err != nil {
@@ -69,18 +66,6 @@ func (r ReconcileMigStorage) validate(storage *migapi.MigStorage) error {
 
 	// Volume snapshot location provider.
 	err = r.validateVSL(storage)
-	if err != nil {
-		return err
-	}
-
-	// Ready
-	storage.Status.SetReady(
-		!storage.Status.HasBlockerCondition(),
-		ReadyMessage)
-
-	// Apply changes.
-	storage.Status.EndStagingConditions()
-	err = r.Update(context.TODO(), storage)
 	if err != nil {
 		return err
 	}
@@ -112,12 +97,6 @@ func (r ReconcileMigStorage) validateBSL(storage *migapi.MigStorage) error {
 	}
 
 	err = r.validateBSLCredsSecret(storage)
-	if err != nil {
-		return err
-	}
-
-	// Update
-	err = r.Update(context.TODO(), storage)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Issue: 
- https://github.com/fusor/mig-controller/issues/120
- https://github.com/fusor/mig-controller/issues/153

The oscillation is caused by the number of `Update()` used to update conditions.  In each controller, the `validate()` effectively clear and re-sets all conditions and updates the resource.  For controllers that manage all conditions in `validate()` the change is _atomic_.  However, the plan controller is a bit more complicated.  It manages the _error_ conditions in `validate()` but manages the _required_ (category) conditions (including `Ready`) elsewhere.  As a result, all of the _required_ conditions (including `Ready`) are removed with the 1st `Update()` and then potentially re-set in the 2nd `Update()`.  Since the plan reconciles a lot, this causes quite a bit of oscillation of the `Ready` condition.  Especially for the Plan.

The fix proposed here is to do condition staging at the reconcile level.  The pattern looks like this:

In `Reconcile()`:
1. Begin condition staging.
2. Validate.
3. Reconcile _things_.
4. Set ready condition.
5. End condition staging.
6. Update.

This pattern would be applied to all controllers.

As a result of the single update, the `Ready` condition will not oscillate unless the resource actually goes in and out of ready on each reconcile.

A potential concern: Currently, the `Ready` condition is cleared quickly at be beginning of each reconcile which means that if the resource is actually no longer ready, resources watching will detect this faster.  As a result of the proposed _single-update_,  the `Ready` condition (removal) can potentially take longer to be updated and noticed by watching resources.  This could be exacerbated by the reconcile being interrupted by an _error_ (or the scheduler).  Since there is always are race condition between resources (and the UI), I believe the potential delay is worth it.  Also, in kube, there is never a guarantee that the _main_ controller for a resource will reconcile first when multiple controllers are watching a resource.  If things are changing that affect readiness while a migration is running, chances are, things are going to get hosed anyway.

This PR includes a change to coerce the controller reconcile ordering to be deterministic for resources being watch by multiple controllers.  This will reduce _some_ of unnecessary reconciles.  But the goal is to ensure that _secondary_ controllers will reconcile only for changes already reconciled by the _main_ controller.  This will make it more intuitive and deterministic which supports easier troubleshooting.  For example, the migration controller will only reconcile changes to the plan after the plan controller has reconciled (that ResourceVersion) first.

While profiling watches and reconciles, I eliminated a few unnecessary resource updates.  As of this PR, each resource is only updated once by their controller at the end of the `Reconcile()`.

Fixes **SEGV** when discovering PVs when the source cluster ref cannot be resolved.  Needs to use `HasAnyCondition()` because `HasCondition()` returns true when matching ALL the specified conditions.