### PR TITLE
Removing extraneous EndStagingConditions calls

### DIFF
--- a/pkg/controller/migplan/registry.go
+++ b/pkg/controller/migplan/registry.go
@@ -73,7 +73,6 @@ func (r ReconcileMigPlan) ensureMigRegistries(plan *migapi.MigPlan) error {
 	} else {
 		plan.Status.DeleteCondition(RegistriesEnsured)
 	}
-	plan.Status.EndStagingConditions()
 	err = r.Update(context.TODO(), plan)
 	if err != nil {
 		return err

--- a/pkg/controller/migplan/storage.go
+++ b/pkg/controller/migplan/storage.go
@@ -66,7 +66,6 @@ func (r ReconcileMigPlan) ensureStorage(plan *migapi.MigPlan) error {
 	} else {
 		plan.Status.DeleteCondition(StorageEnsured)
 	}
-	plan.Status.EndStagingConditions()
 	err = r.Update(context.TODO(), plan)
 	if err != nil {
 		return err


### PR DESCRIPTION
For storage and registry setup, we don't need to call EndStagingConditions
after setting or removing the StorageEnsured or RegistriesEnsured condition
since we're not in a condition staging context.