### PR TITLE
Disable all remote client cache usage, build clients from scratch

### DIFF
--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/fusor/mig-controller/pkg/remote"
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -77,17 +76,21 @@ func (m *MigCluster) GetServiceAccountSecret(client k8sclient.Client) (*kapi.Sec
 
 // GetClient get a local or remote client using a MigCluster and an existing client
 func (m *MigCluster) GetClient(c k8sclient.Client) (k8sclient.Client, error) {
+
 	// If MigCluster isHostCluster, reuse client
 	if m.Spec.IsHostCluster {
 		return c, nil
 	}
-	// If RemoteWatch exists for this cluster, reuse the remote manager's client
-	remoteWatchMap := remote.GetWatchMap()
-	remoteWatchCluster := remoteWatchMap.Get(types.NamespacedName{Namespace: m.Namespace, Name: m.Name})
-	if remoteWatchCluster != nil {
-		return remoteWatchCluster.RemoteManager.GetClient(), nil
-	}
+	/*
+		TODO: re-enable cache after issue with caching secrets is resolved
 
+		// If RemoteWatch exists for this cluster, reuse the remote manager's client
+		remoteWatchMap := remote.GetWatchMap()
+		remoteWatchCluster := remoteWatchMap.Get(types.NamespacedName{Namespace: m.Namespace, Name: m.Name})
+		if remoteWatchCluster != nil {
+			return remoteWatchCluster.RemoteManager.GetClient(), nil
+		}
+	*/
 	// If can't reuse a client from anywhere, build one from scratch without a cache
 	restConfig, err := m.BuildRestConfig(c)
 	if err != nil {


### PR DESCRIPTION
Doing this until we know what is causing `Secret` GET requests to return no secrets directly after the controller starts up. 

Potentially related issues:
https://github.com/fusor/mig-controller/issues/107
https://github.com/fusor/mig-controller/issues/106