### PR TITLE
Additional migration validations and proper sequencing.

### DIFF
--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -22,10 +22,12 @@ import (
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-var log = logf.Log.WithName("controller")
+// Cache Indexes.
+const (
+	PlanIndexField = "planRef"
+)
 
 // MigMigrationSpec defines the desired state of MigMigration
 type MigMigrationSpec struct {
@@ -99,9 +101,19 @@ func (r *MigMigration) MarkAsCompleted() bool {
 	return true
 }
 
+// Get whether the migration is running.
+func (r *MigMigration) IsRunning() bool {
+	return r.Status.MigrationRunning
+}
+
 // Get whether the migration has completed.
 func (r *MigMigration) IsCompleted() bool {
 	return r.Status.MigrationCompleted
+}
+
+// Get whether the migration has failed.
+func (r *MigMigration) HasFailed() bool {
+	return r.IsCompleted() && len(r.Status.Errors) > 0
 }
 
 // Add (de-duplicated) errors.

--- a/pkg/apis/migration/v1alpha1/model.go
+++ b/pkg/apis/migration/v1alpha1/model.go
@@ -14,10 +14,9 @@ import (
 
 // List MigPlans
 // Returns and empty list when none found.
-func ListPlans(client k8sclient.Client, ns string) ([]MigPlan, error) {
+func ListPlans(client k8sclient.Client) ([]MigPlan, error) {
 	list := MigPlanList{}
-	options := k8sclient.InNamespace(ns)
-	err := client.List(context.TODO(), options, &list)
+	err := client.List(context.TODO(), nil, &list)
 	if err != nil {
 		return nil, err
 	}
@@ -114,6 +113,18 @@ func GetStorage(client k8sclient.Client, ref *kapi.ObjectReference) (*MigStorage
 	}
 
 	return &object, err
+}
+
+// List MigMigrations
+// Returns and empty list when none found.
+func ListMigrations(client k8sclient.Client) ([]MigMigration, error) {
+	list := MigMigrationList{}
+	err := client.List(context.TODO(), nil, &list)
+	if err != nil {
+		return nil, err
+	}
+
+	return list.Items, err
 }
 
 // Get a referenced Secret.

--- a/pkg/controller/migmigration/predicate.go
+++ b/pkg/controller/migmigration/predicate.go
@@ -29,7 +29,9 @@ func (r MigrationPredicate) Update(e event.UpdateEvent) bool {
 	if !cast {
 		return true
 	}
-	changed := !reflect.DeepEqual(old.Spec, new.Spec)
+	changed := !reflect.DeepEqual(old.Spec, new.Spec) ||
+		(old.Status.HasCondition(HasFinalMigration) &&
+			!new.Status.HasCondition(HasFinalMigration))
 	if changed {
 		r.unmapRefs(old)
 		r.mapRefs(new)


### PR DESCRIPTION
Related Issues:
- https://github.com/fusor/mig-controller/issues/146
- https://github.com/fusor/mig-controller/issues/86

Changes:
- Prevent migrations from running when the plan is _closed_.  Mainly covers race condition between user updating the plan and the plan controller clearing the `Ready`.
- Prevent migrations (associated with a plan) from running concurrently.
- Prevent any migration from running after a _final_ migration has successfully completed.
- Ensures that migrations are run in the order created with the _final_ migration last.  In practice, multiple migrations should not exist but nothing to prevent the user from doing this.  The goal is deal with it as intuitively and well mannered as possible.
- Ignore reconcile on completed migrations.
- Final migration no longer closes the plan.