### PR TITLE
Update migration workflow to implement 2 stage approach for copy

### DIFF
--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -70,7 +70,7 @@ func (t *Task) ensureInitialBackup() error {
 
 // Ensure the second backup on the source cluster has been created and has the
 // proper settings.
-func (t *Task) ensureCopyBackup() error {
+func (t *Task) ensureStageBackup() error {
 	newBackup, err := t.buildBackup(nil)
 	if err != nil {
 		return err
@@ -91,7 +91,7 @@ func (t *Task) ensureCopyBackup() error {
 		return err
 	}
 	if foundBackup == nil {
-		t.CopyBackup = newBackup
+		t.StageBackup = newBackup
 		client, err := t.getSourceClient()
 		if err != nil {
 			return err
@@ -102,7 +102,7 @@ func (t *Task) ensureCopyBackup() error {
 		}
 		return nil
 	}
-	t.CopyBackup = foundBackup
+	t.StageBackup = foundBackup
 	if !t.equalsBackup(newBackup, foundBackup) {
 		client, err := t.getSourceClient()
 		if err != nil {
@@ -483,7 +483,7 @@ func (t *Task) areStagePodsCreated(resticAnnotationCount int) (bool, error) {
 		}
 	}
 	// Check if all pods are ready
-	if readyCount == podCount {
+	if readyCount == podCount && podCount != 0 {
 		return true, nil
 	}
 	return false, nil

--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -144,6 +144,10 @@ func (t Task) getBackup(copyBackup bool) (*velero.Backup, error) {
 	// Find proper backup to return
 	if len(list.Items) > 0 {
 		for i, backup := range list.Items {
+			// Avoid nil annotation lookup
+			if backup.Annotations == nil {
+				backup.Annotations = make(map[string]string)
+			}
 			if backup.Annotations[copyBackupRestoreAnnotationKey] != "" && copyBackup {
 				return &list.Items[i], nil
 			}

--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -483,6 +483,7 @@ func (t *Task) areStagePodsCreated() (bool, error) {
 func (t *Task) createStagePods() error {
 	client, err := t.getSourceClient()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -495,6 +496,7 @@ func (t *Task) createStagePods() error {
 	podList := corev1.PodList{}
 	err = client.List(context.TODO(), options, &podList)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	for _, pod := range podList.Items {
@@ -527,6 +529,7 @@ func (t *Task) createStagePods() error {
 		if k8serrors.IsAlreadyExists(err) {
 			return nil
 		} else if err != nil {
+			log.Trace(err)
 			return err
 		}
 	}

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -103,7 +103,7 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (int, er
 	switch task.Phase {
 	case WaitOnResticRestart:
 		return 10, nil
-	case InitialBackupFailed, CopyBackupFailed, CopyRestoreFailed, FinalRestoreFailed:
+	case InitialBackupFailed, StageBackupFailed, StageRestoreFailed, FinalRestoreFailed:
 		migration.MarkAsCompleted()
 		migration.AddErrors(task.Errors)
 	case Completed:

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -93,7 +93,7 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (int, er
 	// TODO: SYNC WITH JEFF TO GET OPINION ON THIS HACK
 	// Setting this annotation to not create stage pods after copy restore has
 	// run to completion
-	if task.Phase == DeletingStagePods {
+	if task.Phase == DeleteStagePodsStarted {
 		if migration.Annotations == nil {
 			migration.Annotations = make(map[string]string)
 		}

--- a/pkg/controller/migmigration/quiesce.go
+++ b/pkg/controller/migmigration/quiesce.go
@@ -16,9 +16,13 @@ func (t *Task) quiesceApplications() error {
 	}
 	err := t.scaleDownDCs()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	err = t.scaleDownDeployments()
+	if err != nil {
+		log.Trace(err)
+	}
 	return err
 }
 
@@ -26,6 +30,7 @@ func (t *Task) quiesceApplications() error {
 func (t *Task) scaleDownDCs() error {
 	client, err := t.getSourceClient()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	for _, ns := range t.PlanResources.MigPlan.Spec.Namespaces {
@@ -36,6 +41,7 @@ func (t *Task) scaleDownDCs() error {
 			options,
 			&list)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		for _, dc := range list.Items {
@@ -45,6 +51,7 @@ func (t *Task) scaleDownDCs() error {
 			dc.Spec.Replicas = 0
 			err = client.Update(context.TODO(), &dc)
 			if err != nil {
+				log.Trace(err)
 				return err
 			}
 		}

--- a/pkg/controller/migmigration/quiesce.go
+++ b/pkg/controller/migmigration/quiesce.go
@@ -1,0 +1,34 @@
+package migmigration
+
+import (
+	"context"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (t *Task) scaleDownDCs() error {
+	client, err := t.getSourceClient()
+	if err != nil {
+		return err
+	}
+	for _, ns := range t.PlanResources.MigPlan.Spec.Namespaces {
+		list := appsv1.DeploymentConfigList{}
+		options := k8sclient.InNamespace(ns)
+		err = client.List(
+			context.TODO(),
+			options,
+			&list)
+		if err != nil {
+			return err
+		}
+		for _, dc := range list.Items {
+			dc.Spec.Replicas = 0
+			err = client.Update(context.TODO(), &dc)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/controller/migmigration/quiesce.go
+++ b/pkg/controller/migmigration/quiesce.go
@@ -4,9 +4,25 @@ import (
 	"context"
 
 	appsv1 "github.com/openshift/api/apps/v1"
+	coreappsv1 "k8s.io/api/apps/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// All quiesce functionality should be put here
+func (t *Task) quiesceApplications() error {
+	// If this is stage don't quiesce anything
+	if t.stage() {
+		return nil
+	}
+	err := t.scaleDownDCs()
+	if err != nil {
+		return err
+	}
+	err = t.scaleDownDeployments()
+	return err
+}
+
+// Scales down Deployment Configs on source cluster
 func (t *Task) scaleDownDCs() error {
 	client, err := t.getSourceClient()
 	if err != nil {
@@ -25,6 +41,34 @@ func (t *Task) scaleDownDCs() error {
 		for _, dc := range list.Items {
 			dc.Spec.Replicas = 0
 			err = client.Update(context.TODO(), &dc)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Scales down all Deployments
+func (t *Task) scaleDownDeployments() error {
+	client, err := t.getSourceClient()
+	if err != nil {
+		return err
+	}
+	zeroReplica := int32(0)
+	for _, ns := range t.PlanResources.MigPlan.Spec.Namespaces {
+		list := coreappsv1.DeploymentList{}
+		options := k8sclient.InNamespace(ns)
+		err = client.List(
+			context.TODO(),
+			options,
+			&list)
+		if err != nil {
+			return err
+		}
+		for _, dep := range list.Items {
+			dep.Spec.Replicas = &zeroReplica
+			err = client.Update(context.TODO(), &dep)
 			if err != nil {
 				return err
 			}

--- a/pkg/controller/migmigration/quiesce.go
+++ b/pkg/controller/migmigration/quiesce.go
@@ -39,6 +39,9 @@ func (t *Task) scaleDownDCs() error {
 			return err
 		}
 		for _, dc := range list.Items {
+			if dc.Spec.Replicas == 0 {
+				continue
+			}
 			dc.Spec.Replicas = 0
 			err = client.Update(context.TODO(), &dc)
 			if err != nil {
@@ -53,6 +56,7 @@ func (t *Task) scaleDownDCs() error {
 func (t *Task) scaleDownDeployments() error {
 	client, err := t.getSourceClient()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	zeroReplica := int32(0)
@@ -64,12 +68,17 @@ func (t *Task) scaleDownDeployments() error {
 			options,
 			&list)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		for _, dep := range list.Items {
+			if dep.Spec.Replicas == &zeroReplica {
+				continue
+			}
 			dep.Spec.Replicas = &zeroReplica
 			err = client.Update(context.TODO(), &dep)
 			if err != nil {
+				log.Trace(err)
 				return err
 			}
 		}

--- a/pkg/controller/migmigration/registry.go
+++ b/pkg/controller/migmigration/registry.go
@@ -44,7 +44,7 @@ func (t *Task) getAnnotations(client k8sclient.Client) (map[string]string, error
 		}
 	}
 	if t.quiesce() {
-		annotations[MigQuiesceAnnotationKey] = "true"
+		annotations[migQuiesceAnnotationKey] = "true"
 	}
 	return annotations, nil
 }

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -58,7 +58,7 @@ func (t *Task) ensureFinalRestore() error {
 
 // Ensure the first restore on the destination cluster has been
 // created  and has the proper settings.
-func (t *Task) ensureCopyRestore() error {
+func (t *Task) ensureStageRestore() error {
 	newRestore, err := t.buildRestore(nil)
 	if err != nil {
 		log.Trace(err)
@@ -70,8 +70,8 @@ func (t *Task) ensureCopyRestore() error {
 		return err
 	}
 	if foundRestore == nil {
-		newRestore.Spec.BackupName = t.CopyBackup.Name
-		t.CopyRestore = newRestore
+		newRestore.Spec.BackupName = t.StageBackup.Name
+		t.StageRestore = newRestore
 		client, err := t.getDestinationClient()
 		if err != nil {
 			log.Trace(err)
@@ -84,9 +84,9 @@ func (t *Task) ensureCopyRestore() error {
 		}
 		return nil
 	}
-	t.CopyRestore = foundRestore
+	t.StageRestore = foundRestore
 	if !t.equalsRestore(newRestore, foundRestore) {
-		t.updateRestore(foundRestore, t.CopyBackup.Name)
+		t.updateRestore(foundRestore, t.StageBackup.Name)
 		client, err := t.getDestinationClient()
 		if err != nil {
 			log.Trace(err)
@@ -152,12 +152,12 @@ func (t *Task) buildRestore(includeClusterResources *bool) (*velero.Restore, err
 		log.Trace(err)
 		return nil, err
 	}
-	// Set it to copy backup name since initial backup isn't set on stage
-	backupName := t.CopyBackup.Name
+	// Set it to stage backup name since initial backup isn't set on stage
+	backupName := t.StageBackup.Name
 	// If includeClusterResources isn't set, this means it is first restore to
 	// satisfy moving the persistent storage over
 	if includeClusterResources == nil {
-		backupName = t.CopyBackup.Name
+		backupName = t.StageBackup.Name
 		annotations[copyBackupRestoreAnnotationKey] = "true"
 	} else {
 		backupName = t.InitialBackup.Name

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -125,18 +125,16 @@ func (t Task) getRestore(copyRestore bool) (*velero.Restore, error) {
 		return nil, err
 	}
 	// Find proper restore to return
-	if len(list.Items) > 0 {
-		for i, restore := range list.Items {
-			// Avoid nil dereference
-			if restore.Annotations == nil {
-				restore.Annotations = make(map[string]string)
-			}
-			if restore.Annotations[copyBackupRestoreAnnotationKey] != "" && copyRestore {
-				return &list.Items[i], nil
-			}
-			if restore.Annotations[copyBackupRestoreAnnotationKey] == "" && !copyRestore {
-				return &list.Items[i], nil
-			}
+	for i, restore := range list.Items {
+		// Avoid nil dereference
+		if restore.Annotations == nil {
+			restore.Annotations = make(map[string]string)
+		}
+		if restore.Annotations[copyBackupRestoreAnnotationKey] != "" && copyRestore {
+			return &list.Items[i], nil
+		}
+		if restore.Annotations[copyBackupRestoreAnnotationKey] == "" && !copyRestore {
+			return &list.Items[i], nil
 		}
 	}
 

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -61,10 +61,12 @@ func (t *Task) ensureFinalRestore() error {
 func (t *Task) ensureCopyRestore() error {
 	newRestore, err := t.buildRestore(nil)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	foundRestore, err := t.getRestore(true)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if foundRestore == nil {
@@ -72,10 +74,12 @@ func (t *Task) ensureCopyRestore() error {
 		t.CopyRestore = newRestore
 		client, err := t.getDestinationClient()
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		err = client.Create(context.TODO(), newRestore)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		return nil
@@ -85,10 +89,12 @@ func (t *Task) ensureCopyRestore() error {
 		t.updateRestore(foundRestore, t.CopyBackup.Name)
 		client, err := t.getDestinationClient()
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		err = client.Update(context.TODO(), foundRestore)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 	}

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -127,6 +127,10 @@ func (t Task) getRestore(copyRestore bool) (*velero.Restore, error) {
 	// Find proper restore to return
 	if len(list.Items) > 0 {
 		for i, restore := range list.Items {
+			// Avoid nil dereference
+			if restore.Annotations == nil {
+				restore.Annotations = make(map[string]string)
+			}
 			if restore.Annotations[copyBackupRestoreAnnotationKey] != "" && copyRestore {
 				return &list.Items[i], nil
 			}

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -154,7 +154,7 @@ func (t *Task) Run() error {
 	// This will also return the number of pods we have annotated to be backed up
 	// by restic. This is useful for knowing whether or not we need to create
 	// staging pods
-	err, resticPodCount := t.annotateStorageResources()
+	err, resticAnnotationCount := t.annotateStorageResources()
 	if err != nil {
 		log.Trace(err)
 		return err
@@ -169,7 +169,7 @@ func (t *Task) Run() error {
 
 	// If all stage pods are created and running OR there are no stage pods we
 	// need to create, continue
-	if created || resticPodCount == 0 {
+	if created || resticAnnotationCount == 0 {
 		t.Phase = StagePodsCreated
 	} else if t.Owner.Annotations["openshift.io/stage-completed"] == "" {
 		t.Phase = CreatingStagePods

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -156,12 +156,14 @@ func (t *Task) Run() error {
 	// staging pods
 	err, resticPodCount := t.annotateStorageResources()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
 	// Check if stage pods are created and running
 	created, err := t.areStagePodsCreated()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -174,6 +176,7 @@ func (t *Task) Run() error {
 		// Swap out all copy pods with dummy pods
 		err = t.createStagePods()
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		return nil
@@ -183,6 +186,7 @@ func (t *Task) Run() error {
 	if t.quiesce() {
 		err = t.quiesceApplications()
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 	}
@@ -190,6 +194,7 @@ func (t *Task) Run() error {
 	// Run second backup to copy PV data
 	err = t.ensureCopyBackup()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -279,6 +284,7 @@ func (t *Task) Run() error {
 
 	deleted, err := t.areStagePodsDeleted()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -289,6 +295,7 @@ func (t *Task) Run() error {
 		// Remove staging pods on source and destination cluster
 		err = t.removeStagePods()
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		return nil
@@ -298,6 +305,7 @@ func (t *Task) Run() error {
 	if !t.stage() {
 		err = t.ensureFinalRestore()
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		switch t.FinalRestore.Status.Phase {
@@ -411,10 +419,12 @@ func (t *Task) addErrors(errors []string) {
 func (t *Task) removeStagePods() error {
 	srcClient, err := t.getSourceClient()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	destClient, err := t.getDestinationClient()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	// Find all stage pods
@@ -426,6 +436,7 @@ func (t *Task) removeStagePods() error {
 	podList := corev1.PodList{}
 	err = srcClient.List(context.TODO(), options, &podList)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	for _, pod := range podList.Items {
@@ -433,12 +444,14 @@ func (t *Task) removeStagePods() error {
 			context.TODO(),
 			&pod)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 	}
 	podList = corev1.PodList{}
 	err = destClient.List(context.TODO(), options, &podList)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	for _, pod := range podList.Items {
@@ -446,6 +459,7 @@ func (t *Task) removeStagePods() error {
 			context.TODO(),
 			&pod)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 	}


### PR DESCRIPTION
This PR significantly reworks the migration workflow. The main change is that instead of having just 1 backup and 1 restore, we have 2 backups and 2 restores. The workflow goes like this:

* Backup 1: Captures all resources in the targeted namespaces. This is called `InitialBackup`. This backup explicitly sets `includePersistentVolumes: false` so it only captures resource state, no PV data at all. This backup is *not* run on stage migrations.

* Create Stage Pods: This creates staging "dummy" pods for all pods that have restic annotations. These will be used to copy PV data. The stage pods are rhel7 pods that mount the same volumes.

* Quiesce source application: This does *not* run on stage

* Backup 2: Captures only PVs, PVCs, and Stage Pods. For `copy`, this will perform restic backup/restore on the staging pods. For `move` this will simply swing the PV over

* Restore 1: Runs a restore of Backup 2. This copies all PVCs and PV data over and brings the staging pods to the destination cluster.

* Delete stage pods: This deletes all staging rhel7 pods on both source and destination clusters

* Restore 2: Runs a restore of Backup 1. This brings all application resources over including the original application pods.

**Future Enhancements**

* We could run a check on all PVs to see if there are zero `copy` PVs specified. If there are none, we could simple do the old approach with 1 backup and 1 restore. The backup will set `includePersistentVolumes` to `true`
