### PR TITLE
Error handling and logging.

### DIFF
--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/controller/migcluster/remote_watch.go
+++ b/pkg/controller/migcluster/remote_watch.go
@@ -63,6 +63,7 @@ func StartRemoteWatch(r *ReconcileMigCluster, config remote.ManagerConfig) error
 	log.Info("[rWatch] Starting watch on forwardChannel")
 	err = r.Controller.Watch(&source.Channel{Source: forwardChannel}, &handler.EnqueueRequestForObject{})
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -74,7 +75,7 @@ func StartRemoteWatch(r *ReconcileMigCluster, config remote.ManagerConfig) error
 	}
 	err = remotewatcher.Add(mgr, forwardChannel, forwardEvent)
 	if err != nil {
-		log.Info("[rWatch] Error adding RemoteWatcher controller to manager")
+		log.Error(err, "Error adding RemoteWatcher controller to manager")
 		return err
 	}
 

--- a/pkg/controller/migcluster/validation.go
+++ b/pkg/controller/migcluster/validation.go
@@ -52,18 +52,21 @@ func (r ReconcileMigCluster) validate(cluster *migapi.MigCluster) error {
 	// registry cluster
 	err := r.validateRegistryCluster(cluster)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
 	// SA secret
 	err = r.validateSaSecret(cluster)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
 	// Test Connection
 	err = r.testConnection(cluster)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -92,6 +95,7 @@ func (r ReconcileMigCluster) validateRegistryCluster(cluster *migapi.MigCluster)
 
 	storage, err := r.getCluster(ref)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -155,6 +159,7 @@ func (r ReconcileMigCluster) validateSaSecret(cluster *migapi.MigCluster) error 
 
 	secret, err := migapi.GetSecret(r, ref)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -66,6 +66,7 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (int, er
 	// Resources
 	planResources, err := plan.GetRefResources(r)
 	if err != nil {
+		log.Trace(err)
 		return 0, err
 	}
 

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -16,20 +16,24 @@ const podStageLabel = "migration-stage-pod"
 func (t *Task) ensureRestore() error {
 	newRestore, err := t.buildRestore()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	foundRestore, err := t.getRestore()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if foundRestore == nil {
 		t.Restore = newRestore
 		client, err := t.getDestinationClient()
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		err = client.Create(context.TODO(), newRestore)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		return nil
@@ -39,10 +43,12 @@ func (t *Task) ensureRestore() error {
 		t.updateRestore(foundRestore)
 		client, err := t.getDestinationClient()
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		err = client.Update(context.TODO(), foundRestore)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 	}
@@ -87,6 +93,7 @@ func (t *Task) buildRestore() (*velero.Restore, error) {
 	}
 	annotations, err := t.getAnnotations(client)
 	if err != nil {
+		log.Trace(err)
 		return nil, err
 	}
 	restore := &velero.Restore{
@@ -114,6 +121,7 @@ func (t *Task) updateRestore(restore *velero.Restore) {
 func (t *Task) deleteStagePods() error {
 	client, err := t.getDestinationClient()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	// Find all pods matching the podStageLabel
@@ -125,6 +133,7 @@ func (t *Task) deleteStagePods() error {
 		k8sclient.MatchingLabels(labels),
 		&list)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	// Delete all pods
@@ -133,6 +142,7 @@ func (t *Task) deleteStagePods() error {
 			context.TODO(),
 			&pod)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 	}

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -83,12 +83,14 @@ func (t *Task) Run() error {
 	// would require passing in cluster version to the controller.
 	err := t.bounceResticPod()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
 	// Annotate persistent storage resources with actions
 	err = t.annotateStorageResources()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -100,6 +102,7 @@ func (t *Task) Run() error {
 	// Backup
 	err = t.ensureBackup()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	switch t.Backup.Status.Phase {
@@ -127,6 +130,7 @@ func (t *Task) Run() error {
 	// Delete storage annotations
 	err = t.removeStorageResourceAnnotations()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -134,6 +138,7 @@ func (t *Task) Run() error {
 	t.Phase = WaitOnBackupReplication
 	backup, err := t.getReplicatedBackup()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if backup != nil {
@@ -145,6 +150,7 @@ func (t *Task) Run() error {
 	// Restore
 	err = t.ensureRestore()
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	switch t.Restore.Status.Phase {
@@ -172,6 +178,7 @@ func (t *Task) Run() error {
 	if t.stage() {
 		err = t.deleteStagePods()
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 	}

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -47,12 +47,14 @@ func (r ReconcileMigMigration) validate(migration *migapi.MigMigration) error {
 	// Plan
 	plan, err := r.validatePlan(migration)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
 	// Final migration.
 	err = r.validateFinalMigration(plan, migration)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 

--- a/pkg/controller/migplan/close.go
+++ b/pkg/controller/migplan/close.go
@@ -44,6 +44,7 @@ func (r ReconcileMigPlan) ensureClosed(plan *migapi.MigPlan) error {
 	// Migration Registry
 	err := r.ensureMigRegistriesDelete(plan)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -58,6 +59,7 @@ func (r ReconcileMigPlan) ensureClosed(plan *migapi.MigPlan) error {
 	plan.Touch()
 	err = r.Update(context.TODO(), plan)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 

--- a/pkg/controller/migplan/pvlist.go
+++ b/pkg/controller/migplan/pvlist.go
@@ -26,11 +26,13 @@ func (r *ReconcileMigPlan) updatePvs(plan *migapi.MigPlan) error {
 	// Get srcMigCluster
 	srcMigCluster, err := plan.GetSourceCluster(r.Client)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
 	client, err := srcMigCluster.GetClient(r)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -39,11 +41,13 @@ func (r *ReconcileMigPlan) updatePvs(plan *migapi.MigPlan) error {
 	// Build PV map.
 	table, err := r.getPvMap(client)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	namespaces := plan.Spec.Namespaces
 	claims, err := r.getClaims(client, namespaces)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	for _, claim := range claims {

--- a/pkg/controller/migplan/registry.go
+++ b/pkg/controller/migplan/registry.go
@@ -15,6 +15,7 @@ func (r ReconcileMigPlan) ensureMigRegistries(plan *migapi.MigPlan) error {
 
 	storage, err := plan.GetStorage(r)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if storage == nil {
@@ -22,6 +23,7 @@ func (r ReconcileMigPlan) ensureMigRegistries(plan *migapi.MigPlan) error {
 	}
 	clusters, err := r.planClusters(plan)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -31,30 +33,35 @@ func (r ReconcileMigPlan) ensureMigRegistries(plan *migapi.MigPlan) error {
 		}
 		client, err = cluster.GetClient(r)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 
 		// Migration Registry Secret
 		secret, err := r.ensureRegistrySecret(client, plan, storage)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 
 		// Migration Registry ImageStream
 		err = r.ensureRegistryImageStream(client, plan, secret)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 
 		// Migration Registry DeploymentConfig
 		err = r.ensureRegistryDC(client, plan, storage, secret)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 
 		// Migration Registry Service
 		err = r.ensureRegistryService(client, plan, secret)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 
@@ -108,15 +115,18 @@ func (r ReconcileMigPlan) ensureRegistrySecret(client k8sclient.Client, plan *mi
 func (r ReconcileMigPlan) ensureRegistryImageStream(client k8sclient.Client, plan *migapi.MigPlan, secret *kapi.Secret) error {
 	newImageStream, err := plan.BuildRegistryImageStream(secret.GetName())
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	foundImageStream, err := plan.GetRegistryImageStream(client)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if foundImageStream == nil {
 		err = client.Create(context.TODO(), newImageStream)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		return nil
@@ -127,6 +137,7 @@ func (r ReconcileMigPlan) ensureRegistryImageStream(client k8sclient.Client, pla
 	plan.UpdateRegistryImageStream(foundImageStream)
 	err = client.Update(context.TODO(), foundImageStream)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -139,15 +150,18 @@ func (r ReconcileMigPlan) ensureRegistryDC(client k8sclient.Client, plan *migapi
 	dirName := plan.GetName() + "-registry-" + string(plan.UID)
 	newDC, err := plan.BuildRegistryDC(storage, name, dirName)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	foundDC, err := plan.GetRegistryDC(client)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if foundDC == nil {
 		err = client.Create(context.TODO(), newDC)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		return nil
@@ -158,6 +172,7 @@ func (r ReconcileMigPlan) ensureRegistryDC(client k8sclient.Client, plan *migapi
 	plan.UpdateRegistryDC(storage, foundDC, name, dirName)
 	err = client.Update(context.TODO(), foundDC)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -169,15 +184,18 @@ func (r ReconcileMigPlan) ensureRegistryService(client k8sclient.Client, plan *m
 	name := secret.GetName()
 	newService, err := plan.BuildRegistryService(name)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	foundService, err := plan.GetRegistryService(client)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if foundService == nil {
 		err = client.Create(context.TODO(), newService)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		return nil
@@ -188,6 +206,7 @@ func (r ReconcileMigPlan) ensureRegistryService(client k8sclient.Client, plan *m
 	plan.UpdateRegistryService(foundService, name)
 	err = client.Update(context.TODO(), foundService)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -200,6 +219,7 @@ func (r ReconcileMigPlan) ensureMigRegistriesDelete(plan *migapi.MigPlan) error 
 
 	clusters, err := migapi.ListClusters(r, "")
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -209,29 +229,34 @@ func (r ReconcileMigPlan) ensureMigRegistriesDelete(plan *migapi.MigPlan) error 
 		}
 		client, err = cluster.GetClient(r)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 
 		// Migration Registry Service
 		err = r.ensureRegistryServiceDelete(client, plan)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 
 		// Migration Registry DeploymentConfig
 		err = r.ensureRegistryDCDelete(client, plan)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		// Migration Registry ImageStream
 		err = r.ensureRegistryImageStreamDelete(client, plan)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 
 		// Migration Registry Secret
 		err := r.ensureRegistrySecretDelete(client, plan)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 	}
@@ -243,6 +268,7 @@ func (r ReconcileMigPlan) ensureMigRegistriesDelete(plan *migapi.MigPlan) error 
 func (r ReconcileMigPlan) ensureRegistryServiceDelete(client k8sclient.Client, plan *migapi.MigPlan) error {
 	foundService, err := plan.GetRegistryService(client)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if foundService == nil {
@@ -250,6 +276,7 @@ func (r ReconcileMigPlan) ensureRegistryServiceDelete(client k8sclient.Client, p
 	}
 	err = client.Delete(context.TODO(), foundService)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -260,6 +287,7 @@ func (r ReconcileMigPlan) ensureRegistryServiceDelete(client k8sclient.Client, p
 func (r ReconcileMigPlan) ensureRegistryDCDelete(client k8sclient.Client, plan *migapi.MigPlan) error {
 	foundDC, err := plan.GetRegistryDC(client)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if foundDC == nil {
@@ -267,6 +295,7 @@ func (r ReconcileMigPlan) ensureRegistryDCDelete(client k8sclient.Client, plan *
 	}
 	err = client.Delete(context.TODO(), foundDC)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -277,6 +306,7 @@ func (r ReconcileMigPlan) ensureRegistryDCDelete(client k8sclient.Client, plan *
 func (r ReconcileMigPlan) ensureRegistryImageStreamDelete(client k8sclient.Client, plan *migapi.MigPlan) error {
 	foundImageStream, err := plan.GetRegistryImageStream(client)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if foundImageStream == nil {
@@ -284,6 +314,7 @@ func (r ReconcileMigPlan) ensureRegistryImageStreamDelete(client k8sclient.Clien
 	}
 	err = client.Delete(context.TODO(), foundImageStream)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -294,6 +325,7 @@ func (r ReconcileMigPlan) ensureRegistryImageStreamDelete(client k8sclient.Clien
 func (r ReconcileMigPlan) ensureRegistrySecretDelete(client k8sclient.Client, plan *migapi.MigPlan) error {
 	foundSecret, err := plan.GetRegistrySecret(client)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if foundSecret == nil {
@@ -301,6 +333,7 @@ func (r ReconcileMigPlan) ensureRegistrySecretDelete(client k8sclient.Client, pl
 	}
 	err = client.Delete(context.TODO(), foundSecret)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 

--- a/pkg/controller/migplan/storage.go
+++ b/pkg/controller/migplan/storage.go
@@ -15,6 +15,7 @@ func (r ReconcileMigPlan) ensureStorage(plan *migapi.MigPlan) error {
 
 	storage, err := plan.GetStorage(r)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if storage == nil {
@@ -22,6 +23,7 @@ func (r ReconcileMigPlan) ensureStorage(plan *migapi.MigPlan) error {
 	}
 	clusters, err := r.planClusters(plan)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -31,23 +33,27 @@ func (r ReconcileMigPlan) ensureStorage(plan *migapi.MigPlan) error {
 		}
 		client, err = cluster.GetClient(r)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		// BSL
 		err := r.ensureBSL(client, storage)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 
 		// VSL
 		err = r.ensureVSL(client, storage)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 
 		// Cloud Secret
 		err = r.ensureCloudSecret(client, storage)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 
@@ -73,11 +79,13 @@ func (r ReconcileMigPlan) ensureBSL(client k8sclient.Client, storage *migapi.Mig
 	newBSL := storage.BuildBSL()
 	foundBSL, err := storage.GetBSL(client)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if foundBSL == nil {
 		err = client.Create(context.TODO(), newBSL)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		return nil
@@ -88,6 +96,7 @@ func (r ReconcileMigPlan) ensureBSL(client k8sclient.Client, storage *migapi.Mig
 	storage.UpdateBSL(foundBSL)
 	err = client.Update(context.TODO(), foundBSL)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -100,11 +109,13 @@ func (r ReconcileMigPlan) ensureVSL(client k8sclient.Client, storage *migapi.Mig
 	newVSL := storage.BuildVSL()
 	foundVSL, err := storage.GetVSL(client)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if foundVSL == nil {
 		err = client.Create(context.TODO(), newVSL)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		return nil
@@ -115,6 +126,7 @@ func (r ReconcileMigPlan) ensureVSL(client k8sclient.Client, storage *migapi.Mig
 	storage.UpdateVSL(foundVSL)
 	err = client.Update(context.TODO(), foundVSL)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -125,15 +137,18 @@ func (r ReconcileMigPlan) ensureVSL(client k8sclient.Client, storage *migapi.Mig
 func (r ReconcileMigPlan) ensureCloudSecret(client k8sclient.Client, storage *migapi.MigStorage) error {
 	newSecret, err := storage.BuildCloudSecret(r)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	foundSecret, err := storage.GetCloudSecret(client)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if foundSecret == nil {
 		err = client.Create(context.TODO(), newSecret)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		return nil
@@ -144,6 +159,7 @@ func (r ReconcileMigPlan) ensureCloudSecret(client k8sclient.Client, storage *mi
 	storage.UpdateCloudSecret(r, foundSecret)
 	err = client.Update(context.TODO(), foundSecret)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -82,30 +82,35 @@ func (r ReconcileMigPlan) validate(plan *migapi.MigPlan) error {
 	// Source cluster
 	err := r.validateSourceCluster(plan)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
 	// Destination cluster
 	err = r.validateDestinationCluster(plan)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
 	// Storage
 	err = r.validateStorage(plan)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
 	// Migrated namespaces.
 	err = r.validateNamespaces(plan)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
 	// Required namespaces.
 	err = r.validateRequiredNamespaces(plan)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -130,6 +135,7 @@ func (r ReconcileMigPlan) validateStorage(plan *migapi.MigPlan) error {
 
 	storage, err := migapi.GetStorage(r, ref)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -192,6 +198,7 @@ func (r ReconcileMigPlan) validateSourceCluster(plan *migapi.MigPlan) error {
 
 	cluster, err := migapi.GetCluster(r, ref)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -251,6 +258,7 @@ func (r ReconcileMigPlan) validateDestinationCluster(plan *migapi.MigPlan) error
 
 	cluster, err := migapi.GetCluster(r, ref)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -285,12 +293,14 @@ func (r ReconcileMigPlan) validateRequiredNamespaces(plan *migapi.MigPlan) error
 	// Source
 	err := r.validateSourceNamespaces(plan)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
 	// Destination
 	err = r.validateDestinationNamespaces(plan)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -306,6 +316,7 @@ func (r ReconcileMigPlan) validateSourceNamespaces(plan *migapi.MigPlan) error {
 	}
 	cluster, err := plan.GetSourceCluster(r)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if cluster == nil || !cluster.Status.IsReady() {
@@ -313,6 +324,7 @@ func (r ReconcileMigPlan) validateSourceNamespaces(plan *migapi.MigPlan) error {
 	}
 	client, err := cluster.GetClient(r)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	ns := kapi.Namespace{}
@@ -326,6 +338,7 @@ func (r ReconcileMigPlan) validateSourceNamespaces(plan *migapi.MigPlan) error {
 		if errors.IsNotFound(err) {
 			notFound = append(notFound, name)
 		} else {
+			log.Trace(err)
 			return err
 		}
 	}
@@ -350,6 +363,7 @@ func (r ReconcileMigPlan) validateDestinationNamespaces(plan *migapi.MigPlan) er
 	namespaces := []string{migapi.VeleroNamespace}
 	cluster, err := plan.GetDestinationCluster(r)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	if cluster == nil || !cluster.Status.IsReady() {
@@ -357,6 +371,7 @@ func (r ReconcileMigPlan) validateDestinationNamespaces(plan *migapi.MigPlan) er
 	}
 	client, err := cluster.GetClient(r)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	ns := kapi.Namespace{}
@@ -370,6 +385,7 @@ func (r ReconcileMigPlan) validateDestinationNamespaces(plan *migapi.MigPlan) er
 		if errors.IsNotFound(err) {
 			notFound = append(notFound, name)
 		} else {
+			log.Trace(err)
 			return err
 		}
 	}

--- a/pkg/controller/migstorage/storage.go
+++ b/pkg/controller/migstorage/storage.go
@@ -11,10 +11,12 @@ import (
 func (r ReconcileMigStorage) deleteVeleroResources(storage *migapi.MigStorage) error {
 	err := r.deleteBSLs(storage)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	err = r.deleteVSLs(storage)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	return nil
@@ -25,12 +27,14 @@ func (r ReconcileMigStorage) deleteBSLs(storage *migapi.MigStorage) error {
 	var client k8sclient.Client
 	clusters, err := migapi.ListClusters(r, storage.Namespace)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 	for _, cluster := range clusters {
 		if !cluster.Spec.IsHostCluster {
 			client, err = cluster.GetClient(r)
 			if err != nil {
+				log.Trace(err)
 				return err
 			}
 		} else {
@@ -39,11 +43,13 @@ func (r ReconcileMigStorage) deleteBSLs(storage *migapi.MigStorage) error {
 		newLocation := storage.BuildBSL()
 		location, err := storage.GetBSL(client)
 		if err != nil {
+			log.Trace(err)
 			return err
 		}
 		if location != nil {
 			err = client.Delete(context.TODO(), newLocation)
 			if err != nil {
+				log.Trace(err)
 				return err
 			}
 		}

--- a/pkg/controller/migstorage/validation.go
+++ b/pkg/controller/migstorage/validation.go
@@ -61,12 +61,14 @@ func (r ReconcileMigStorage) validate(storage *migapi.MigStorage) error {
 	// Backup location provider.
 	err := r.validateBSL(storage)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
 	// Volume snapshot location provider.
 	err = r.validateVSL(storage)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -98,6 +100,7 @@ func (r ReconcileMigStorage) validateBSL(storage *migapi.MigStorage) error {
 
 	err = r.validateBSLCredsSecret(storage)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -185,6 +188,7 @@ func (r ReconcileMigStorage) validateBSLCredsSecret(storage *migapi.MigStorage) 
 
 	secret, err := migapi.GetSecret(r, ref)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -240,6 +244,7 @@ func (r ReconcileMigStorage) validateVSL(storage *migapi.MigStorage) error {
 
 	err = r.validateVSLCredsSecret(storage)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -320,6 +325,7 @@ func (r ReconcileMigStorage) validateVSLCredsSecret(storage *migapi.MigStorage) 
 
 	secret, err := migapi.GetSecret(r, ref)
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 

--- a/pkg/controller/remotewatcher/remotewatcher_controller.go
+++ b/pkg/controller/remotewatcher/remotewatcher_controller.go
@@ -14,6 +14,7 @@ limitations under the License.
 package remotewatcher
 
 import (
+	"github.com/fusor/mig-controller/pkg/logging"
 	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,11 +24,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("remote-watch")
+var log = logging.WithName("remote-watch")
 
 // Add creates a new RemoteWatcher Controller with a forwardChannel
 func Add(mgr manager.Manager, forwardChannel chan event.GenericEvent, fowardEvent event.GenericEvent) error {
@@ -51,6 +51,7 @@ func newReconciler(
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	c, err := controller.New("remotewatcher-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -62,6 +63,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		&handler.EnqueueRequestForObject{},
 		&BackupPredicate{})
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -73,6 +75,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		&handler.EnqueueRequestForObject{},
 		&RestorePredicate{})
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -84,6 +87,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		&handler.EnqueueRequestForObject{},
 		&BSLPredicate{})
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -95,6 +99,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		&handler.EnqueueRequestForObject{},
 		&VSLPredicate{})
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -106,6 +111,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		&handler.EnqueueRequestForObject{},
 		&SecretPredicate{})
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -117,6 +123,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		&handler.EnqueueRequestForObject{},
 		&PodPredicate{})
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -127,6 +134,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		},
 		&handler.EnqueueRequestForObject{})
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -137,6 +145,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		},
 		&handler.EnqueueRequestForObject{})
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -147,6 +156,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		},
 		&handler.EnqueueRequestForObject{})
 	if err != nil {
+		log.Trace(err)
 		return err
 	}
 
@@ -170,6 +180,7 @@ type ReconcileRemoteWatcher struct {
 // +kubebuilder:rbac:groups=image.openshift.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.openshift.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 func (r *ReconcileRemoteWatcher) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log.Reset()
 	// Forward a known Event back to the parent controller
 	r.ForwardChannel <- r.ForwardEvent
 	return reconcile.Result{}, nil

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -1,0 +1,88 @@
+package logging
+
+import (
+	"fmt"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/storage/names"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+// Logger
+// Delegates functionality to the wrapped `Real` logger.
+// Provides:
+//   - Prevents duplicate logging of the same error.
+//   - Provides a `Trace()` method for convenience and brevity.
+//   - Prevent spamming the log with `Conflict` errors.
+type Logger struct {
+	Real    logr.Logger
+	history map[error]bool
+	name    string
+}
+
+// Get a named logger.
+func WithName(name string) Logger {
+	logger := Logger{
+		Real: logf.Log.WithName(name),
+		name: name,
+	}
+	logger.Reset()
+	return logger
+}
+
+// Reset the logger.
+// Updates the generated correlation suffix in the name and
+// clears the reported error history.
+func (l *Logger) Reset() {
+	name := fmt.Sprintf("%s|", l.name)
+	name = names.SimpleNameGenerator.GenerateName(name)
+	l.Real = logf.Log.WithName(name)
+	l.history = make(map[error]bool)
+}
+
+// Logs at info.
+func (l Logger) Info(message string, kvpair ...interface{}) {
+	l.Real.Info(message, kvpair...)
+}
+
+// Logs an error.
+// Previously logged errors are ignored.
+// `Conflict` errors are not logged.
+func (l Logger) Error(err error, message string, kvpair ...interface{}) {
+	if err == nil {
+		return
+	}
+	_, found := l.history[err]
+	if found || errors.IsConflict(err) {
+		return
+	}
+	l.Real.Error(err, message, kvpair...)
+	l.history[err] = true
+}
+
+// Logs an error without a description.
+func (l Logger) Trace(err error, kvpair ...interface{}) {
+	l.Error(err, "", kvpair...)
+}
+
+// Get whether logger is enabled.
+func (l Logger) Enabled() bool {
+	return l.Real.Enabled()
+}
+
+// Get logger with verbosity level.
+func (l Logger) V(level int) logr.InfoLogger {
+	return l.Real.V(level)
+}
+
+// Get logger with name.
+func (l Logger) WithName(name string) logr.Logger {
+	l.Real = l.Real.WithName(name)
+	return l
+}
+
+// Get logger with values.
+func (l Logger) WithValues(kvpair ...interface{}) logr.Logger {
+	l.Real = l.Real.WithValues(kvpair...)
+	return l
+}


### PR DESCRIPTION
Problem:
---
The error handling philosophy in the controller is to _bubble up_ all errors to `Reconcile()` which in-turn returns the _error_.  As a result, the _caller_, in controller-runtime framework, logs the _error_ with a stack trace which ends at the Reconcile() and does not the controller code where the _error_ was encountered.

Solution Summary:
---
- Errors continue to be _bubble up_ (be returned) to the Reconcile().
- Errors are logged where they are detected.  `If err != nil`
- The Reconcile() will return `reconcole.Result{Requeue: true}, nil` instead of `reconcole.Result{}, err` 

Details:
---
 In order for stack traces to be useful, An _error_ need to be logged using `Logger.Error()` where the error is encountered.  Because the policy in the controller is to return errors up the call stack, it's not clear as to whether an error is logged or not.  So, each:
```
if err != nil {
  return nil
}
``` 
should be something like:
```
if err != nil {
  log.Error(err, "...")
  return nil
}
``` 
In some sense, this feels excessive.  However, it ensures that all errors are logged with a useful stack trace. and can be easily verified through code inspection/review.

However, doing this with a _stock_ logger will likely result in the same error being logged many times.  Also, there are errors we don't want to log.  Such as `IsConflict(err)` and `IsNotFound(err)`.  Adding the `if error.IsConflict(err)` in so many places adds clutter and seems avoidable.

To address all of these issues, the PR includes a custom logger that provides:

- `WithName()` factory method to create a logger named as (example): `migplan|x9f4j`.  Currently this is done in every controller.
- Ensures each error logged during a Reconcile() is only logged once.
- Omit _Conflict_ and _NotFound_ errors.
- Provides a `Logger.Trace()` convenience method. In most cases, the stack trace contains all of the information needed and an additional _message_ is likely to just be a rewording of the name of _top_ function in the stack.  

This PR includes the custom `Logger` and changes:
```
if err != nil {
  return nil
}
``` 
To:
```
if err != nil {
  log.Trace(err)
  return nil
}
``` 
Everywhere.

The `Trace()` can be replace with `Error()` where a _message_ will provide value.  Or, key-value pairs can be added to the `Trace()` as needed.