### PR TITLE
Ordered phases.

### DIFF
--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -210,9 +210,9 @@ func (t *Task) getReplicatedBackup() (*velero.Backup, error) {
 // This function is used to get around mount propagation requirements
 func (t *Task) bounceResticPod() error {
 	// If restart already completed, return
-	if t.Phase != WaitOnResticRestart && t.Phase != Started {
+	if !t.Phase.Equals(WaitOnResticRestart) && !t.Phase.Equals(Started) {
 		return nil
-	} else if t.Phase == WaitOnResticRestart {
+	} else if t.Phase.Equals(WaitOnResticRestart) {
 		t.Log.Info("Waiting for restic pod to be ready")
 	}
 
@@ -246,8 +246,8 @@ func (t *Task) bounceResticPod() error {
 			continue
 		}
 		// If restart already started, mark it as completed
-		if t.Phase == WaitOnResticRestart {
-			t.Phase = ResticRestartCompleted
+		if t.Phase.Equals(WaitOnResticRestart) {
+			t.Phase.Set(ResticRestartCompleted)
 			t.Log.Info("Restic pod successfully restarted")
 			return nil
 		}
@@ -263,7 +263,7 @@ func (t *Task) bounceResticPod() error {
 			log.Trace(err)
 			return err
 		}
-		t.Phase = WaitOnResticRestart
+		t.Phase.Set(WaitOnResticRestart)
 		return nil
 	}
 


### PR DESCRIPTION
The _int_ phase adds (a little) complexity to the CR and but has the advantage of supporting _int_ comparisons.  However since the ordering is tied to the phase (number) phases cannot be re-ordered without changing their value.  Also, storing both a phase _name_ and _number_ in the Status is effectively two representations of the same data that could conflict (although unlikely).

Another approach is to define ordering for the existing _string_ phases and introduce a _struct_ to isolate the complexity.  This supports changing the order without impact to existing migrations and the `MigMigration.Status.Phase` is unchanged.  It also supports various methods to inspecting the phase.