### PR TITLE
Usability enhancements for correlation labels.

### DIFF
--- a/pkg/apis/migration/v1alpha1/labels.go
+++ b/pkg/apis/migration/v1alpha1/labels.go
@@ -8,21 +8,19 @@ import (
 
 // All known correlation labels.
 var KnownLabels = map[string]bool{
-	label(MigPlan{}):      true,
-	label(MigCluster{}):   true,
-	label(MigStorage{}):   true,
-	label(MigMigration{}): true,
+	labelKey(MigPlan{}):      true,
+	labelKey(MigCluster{}):   true,
+	labelKey(MigStorage{}):   true,
+	labelKey(MigMigration{}): true,
 }
 
-// Build  labels used to correlate CRs.
+// Build label (key, value) used to correlate CRs.
 // Format: <kind>: <uid>.  The <uid> should be the ObjectMeta.UID
-func buildCorrelationLabels(r interface{}, uid types.UID) map[string]string {
-	return map[string]string{
-		label(r): string(uid),
-	}
+func CorrelationLabel(r interface{}, uid types.UID) (key, value string) {
+	return labelKey(r), string(uid)
 }
 
 // Get a label (key) for the specified CR kind.
-func label(r interface{}) string {
+func labelKey(r interface{}) string {
 	return strings.ToLower(migref.ToKind(r))
 }

--- a/pkg/apis/migration/v1alpha1/resource.go
+++ b/pkg/apis/migration/v1alpha1/resource.go
@@ -14,9 +14,10 @@ const (
 // provide remote watch predicates the ability to determine
 // when an updated referenced resource has been fully reconciled.
 type MigResource interface {
-	// Get the correlation labels.
-	// Labels are used as a back-reference to this resource.
+	// Get a map containing the correlation label.
 	GetCorrelationLabels() map[string]string
+	// Get the correlation label (key, value).
+	GetCorrelationLabel() (string, string)
 	// Get the resource namespace.
 	GetNamespace() string
 	// Get the resource name.
@@ -29,7 +30,14 @@ type MigResource interface {
 
 // Plan
 func (r *MigPlan) GetCorrelationLabels() map[string]string {
-	return buildCorrelationLabels(r, r.UID)
+	key, value := r.GetCorrelationLabel()
+	return map[string]string{
+		key: value,
+	}
+}
+
+func (r *MigPlan) GetCorrelationLabel() (string, string) {
+	return CorrelationLabel(r, r.UID)
 }
 
 func (r *MigPlan) GetNamespace() string {
@@ -61,7 +69,14 @@ func (r *MigPlan) Touch() {
 
 // Storage
 func (r *MigStorage) GetCorrelationLabels() map[string]string {
-	return buildCorrelationLabels(r, r.UID)
+	key, value := r.GetCorrelationLabel()
+	return map[string]string{
+		key: value,
+	}
+}
+
+func (r *MigStorage) GetCorrelationLabel() (string, string) {
+	return CorrelationLabel(r, r.UID)
 }
 
 func (r *MigStorage) GetNamespace() string {
@@ -93,7 +108,14 @@ func (r *MigStorage) Touch() {
 
 // Cluster
 func (r *MigCluster) GetCorrelationLabels() map[string]string {
-	return buildCorrelationLabels(r, r.UID)
+	key, value := r.GetCorrelationLabel()
+	return map[string]string{
+		key: value,
+	}
+}
+
+func (r *MigCluster) GetCorrelationLabel() (string, string) {
+	return CorrelationLabel(r, r.UID)
 }
 
 func (r *MigCluster) GetNamespace() string {
@@ -125,7 +147,14 @@ func (r *MigCluster) Touch() {
 
 // Migration
 func (r *MigMigration) GetCorrelationLabels() map[string]string {
-	return buildCorrelationLabels(r, r.UID)
+	key, value := r.GetCorrelationLabel()
+	return map[string]string{
+		key: value,
+	}
+}
+
+func (r *MigMigration) GetCorrelationLabel() (string, string) {
+	return CorrelationLabel(r, r.UID)
 }
 
 func (r *MigMigration) GetNamespace() string {


### PR DESCRIPTION
Add `MigResource.GetCorrelationLabel() (key,  value string)` to support adding/deleting the _correlation_ label on existing resources.