### PR TITLE
Add Running, Succeeded and Failed conditions.

### DIFF
--- a/config/crds/migration_v1alpha1_migmigration.yaml
+++ b/config/crds/migration_v1alpha1_migmigration.yaml
@@ -39,17 +39,10 @@ spec:
           type: object
         status:
           properties:
-            completionTimestamp:
-              format: date-time
-              type: string
             errors:
               items:
                 type: string
               type: array
-            migrationCompleted:
-              type: boolean
-            migrationStarted:
-              type: boolean
             phase:
               type: string
             startTimestamp:

--- a/pkg/apis/migration/v1alpha1/condition.go
+++ b/pkg/apis/migration/v1alpha1/condition.go
@@ -22,11 +22,13 @@ const (
 // Error - Errors that block the `Ready` condition.
 // Warn - Warnings that do not block the `Ready` condition.
 // Required - Required for the `Ready` condition.
+// Advisory - An advisory condition.
 const (
 	Critical = "Critical"
 	Error    = "Error"
 	Warn     = "Warn"
 	Required = "Required"
+	Advisory = "Advisory"
 )
 
 // Condition

--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"time"
-
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,12 +37,9 @@ type MigMigrationSpec struct {
 // MigMigrationStatus defines the observed state of MigMigration
 type MigMigrationStatus struct {
 	Conditions
-	MigrationRunning    bool         `json:"migrationStarted,omitempty"`
-	MigrationCompleted  bool         `json:"migrationCompleted,omitempty"`
-	StartTimestamp      *metav1.Time `json:"startTimestamp,omitempty"`
-	CompletionTimestamp *metav1.Time `json:"completionTimestamp,omitempty"`
-	Phase               string       `json:"phase,omitempty"`
-	Errors              []string     `json:"errors,omitempty"`
+	StartTimestamp *metav1.Time `json:"startTimestamp,omitempty"`
+	Phase          string       `json:"phase,omitempty"`
+	Errors         []string     `json:"errors,omitempty"`
 }
 
 // +genclient
@@ -77,43 +72,6 @@ func init() {
 // Returns `nil` when the reference cannot be resolved.
 func (r *MigMigration) GetPlan(client k8sclient.Client) (*MigPlan, error) {
 	return GetPlan(client, r.Spec.MigPlanRef)
-}
-
-// MarkAsRunning marks the MigMigration status as 'Running'. Returns true if changed.
-func (r *MigMigration) MarkAsRunning() bool {
-	if r.Status.MigrationCompleted == true || r.Status.MigrationRunning == true {
-		return false
-	}
-	r.Status.MigrationRunning = true
-	r.Status.MigrationCompleted = false
-	r.Status.StartTimestamp = &metav1.Time{Time: time.Now()}
-	return true
-}
-
-// MarkAsCompleted marks the MigMigration status as 'Completed'. Returns true if changed.
-func (r *MigMigration) MarkAsCompleted() bool {
-	if r.Status.MigrationRunning == false || r.Status.MigrationCompleted == true {
-		return false
-	}
-	r.Status.MigrationRunning = false
-	r.Status.MigrationCompleted = true
-	r.Status.CompletionTimestamp = &metav1.Time{Time: time.Now()}
-	return true
-}
-
-// Get whether the migration is running.
-func (r *MigMigration) IsRunning() bool {
-	return r.Status.MigrationRunning
-}
-
-// Get whether the migration has completed.
-func (r *MigMigration) IsCompleted() bool {
-	return r.Status.MigrationCompleted
-}
-
-// Get whether the migration has failed.
-func (r *MigMigration) HasFailed() bool {
-	return r.IsCompleted() && len(r.Status.Errors) > 0
 }
 
 // Add (de-duplicated) errors.

--- a/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
@@ -279,10 +279,6 @@ func (in *MigMigrationStatus) DeepCopyInto(out *MigMigrationStatus) {
 		in, out := &in.StartTimestamp, &out.StartTimestamp
 		*out = (*in).DeepCopy()
 	}
-	if in.CompletionTimestamp != nil {
-		in, out := &in.CompletionTimestamp, &out.CompletionTimestamp
-		*out = (*in).DeepCopy()
-	}
 	if in.Errors != nil {
 		in, out := &in.Errors, &out.Errors
 		*out = make([]string, len(*in))

--- a/pkg/controller/migmigration/validation.go
+++ b/pkg/controller/migmigration/validation.go
@@ -12,11 +12,15 @@ const (
 	PlanClosed        = "PlanClosed"
 	HasFinalMigration = "HasFinalMigration"
 	Postponed         = "Postponed"
+	Running           = "Running"
+	Succeeded         = "Succeeded"
+	Failed            = "Failed"
 )
 
 // Categories
 const (
 	Critical = migapi.Critical
+	Advisory = migapi.Advisory
 )
 
 // Reasons
@@ -39,6 +43,9 @@ const (
 	PlanClosedMessage        = "The associated migration plan is closed."
 	HasFinalMigrationMessage = "The associated MigPlan already has a final migration."
 	PostponedMessage         = "Postponed %d seconds to ensure migrations run serially and in order."
+	RunningMessage           = "The migration is running."
+	FailedMessage            = "The migration has failed.  See: Errors."
+	SucceededMessage         = "The migration has completed successfully."
 )
 
 // Validate the plan resource.
@@ -141,14 +148,14 @@ func (r ReconcileMigMigration) validateFinalMigration(plan *migapi.MigPlan, migr
 		}
 		// Stage
 		if migration.Spec.Stage {
-			if m.IsCompleted() || m.IsRunning() {
+			if m.Status.HasAnyCondition(Running, Succeeded, Failed) {
 				hasCondition = true
 				break
 			}
 		}
 		// Final
 		if !migration.Spec.Stage {
-			if m.IsCompleted() && !m.HasFailed() {
+			if m.Status.HasCondition(Succeeded) {
 				hasCondition = true
 				break
 			}


### PR DESCRIPTION
Provide the user with a single method to determine the status of a migration.

Add conditions for _Running_, _Succeeded_ and _Failed_.  The _Succeeded_ and _Failed_ conditions obsoletes the `Status.MigrationCompleted` field.  The _Running_ condition obsoletes the `Status.MigrationStarted` field.  The `Status.StartedTimestamp` is needed to support ordering migrations in the order they _ran_.

The `Condition.Reason` for the _Running_, _Succeeded_ and _Failed_ conditions is the Task.Phase.  This should further the goal of minimizing the users usage of phase.