### PR TITLE
Stateless migration with new migration workflow

### DIFF
--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -259,7 +259,7 @@ func (t *Task) updateBackup(backup *velero.Backup) error {
 
 // Determine whether backups are replicated by velero on the destination
 // cluster.
-func (t *Task) areBackupsReplicated() (bool, error) {
+func (t *Task) areBackupsReplicated(isInitial bool) (bool, error) {
 	client, err := t.getDestinationClient()
 	if err != nil {
 		return false, err
@@ -274,7 +274,7 @@ func (t *Task) areBackupsReplicated() (bool, error) {
 		return false, err
 	}
 	// If this is stage we only need to wait for 1 backup to be replicated
-	if len(list.Items) == 1 && t.stage() {
+	if len(list.Items) == 1 && (t.stage() || isInitial) {
 		return true, nil
 	}
 	// If this is not a stage, we need to find 2 backups before continuing

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -101,6 +101,16 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (int, er
 		Message:  RunningMessage,
 	})
 
+	// TODO: SYNC WITH JEFF TO GET OPINION ON THIS HACK
+	// Setting this annotation to not create stage pods after copy restore has
+	// run to completion
+	if task.Phase.Equals(DeleteStagePodsStarted) {
+		if migration.Annotations == nil {
+			migration.Annotations = make(map[string]string)
+		}
+		migration.Annotations["openshift.io/stage-completed"] = "true"
+	}
+
 	// Result
 	migration.Status.Phase = task.Phase.Name
 	if task.Phase.Equals(WaitOnResticRestart) {

--- a/pkg/controller/migmigration/quiesce.go
+++ b/pkg/controller/migmigration/quiesce.go
@@ -1,0 +1,94 @@
+package migmigration
+
+import (
+	"context"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+	coreappsv1 "k8s.io/api/apps/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// All quiesce functionality should be put here
+func (t *Task) quiesceApplications() error {
+	// If this is stage don't quiesce anything
+	if t.stage() {
+		return nil
+	}
+	err := t.scaleDownDCs()
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	err = t.scaleDownDeployments()
+	if err != nil {
+		log.Trace(err)
+	}
+	return err
+}
+
+// Scales down Deployment Configs on source cluster
+func (t *Task) scaleDownDCs() error {
+	client, err := t.getSourceClient()
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	for _, ns := range t.PlanResources.MigPlan.Spec.Namespaces {
+		list := appsv1.DeploymentConfigList{}
+		options := k8sclient.InNamespace(ns)
+		err = client.List(
+			context.TODO(),
+			options,
+			&list)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		for _, dc := range list.Items {
+			if dc.Spec.Replicas == 0 {
+				continue
+			}
+			dc.Spec.Replicas = 0
+			err = client.Update(context.TODO(), &dc)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Scales down all Deployments
+func (t *Task) scaleDownDeployments() error {
+	client, err := t.getSourceClient()
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	zeroReplica := int32(0)
+	for _, ns := range t.PlanResources.MigPlan.Spec.Namespaces {
+		list := coreappsv1.DeploymentList{}
+		options := k8sclient.InNamespace(ns)
+		err = client.List(
+			context.TODO(),
+			options,
+			&list)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		for _, dep := range list.Items {
+			if dep.Spec.Replicas == &zeroReplica {
+				continue
+			}
+			dep.Spec.Replicas = &zeroReplica
+			err = client.Update(context.TODO(), &dep)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/controller/migmigration/registry.go
+++ b/pkg/controller/migmigration/registry.go
@@ -44,7 +44,7 @@ func (t *Task) getAnnotations(client k8sclient.Client) (map[string]string, error
 		}
 	}
 	if t.quiesce() {
-		annotations[MigQuiesceAnnotationKey] = "true"
+		annotations[migQuiesceAnnotationKey] = "true"
 	}
 	return annotations, nil
 }

--- a/pkg/controller/migmigration/restore.go
+++ b/pkg/controller/migmigration/restore.go
@@ -2,6 +2,7 @@ package migmigration
 
 import (
 	"context"
+
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	velero "github.com/heptio/velero/pkg/apis/velero/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -152,8 +153,7 @@ func (t *Task) buildRestore(includeClusterResources *bool) (*velero.Restore, err
 		log.Trace(err)
 		return nil, err
 	}
-	// Set it to stage backup name since initial backup isn't set on stage
-	backupName := t.StageBackup.Name
+	backupName := ""
 	// If includeClusterResources isn't set, this means it is first restore to
 	// satisfy moving the persistent storage over
 	if includeClusterResources == nil {

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -1,47 +1,72 @@
 package migmigration
 
 import (
+	"context"
 	"fmt"
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/go-logr/logr"
 	velero "github.com/heptio/velero/pkg/apis/velero/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Annotation Keys
-const MigQuiesceAnnotationKey = "openshift.io/migrate-quiesce-pods"
+const (
+	migQuiesceAnnotationKey        = "openshift.io/migrate-quiesce-pods"
+	copyBackupRestoreAnnotationKey = "openshift.io/copy-backup-restore"
+)
 
 // Phases
 const (
-	Created                 = ""
-	Started                 = "Started"
-	WaitOnResticRestart     = "WaitOnResticRestart"
-	ResticRestartCompleted  = "ResticRestartCompleted"
-	BackupStarted           = "BackupStarted"
-	BackupCompleted         = "BackupCompleted"
-	BackupFailed            = "BackupFailed"
-	WaitOnBackupReplication = "WaitOnBackupReplication"
-	BackupReplicated        = "BackupReplicated"
-	RestoreStarted          = "RestoreStarted"
-	RestoreCompleted        = "RestoreCompleted"
-	RestoreFailed           = "RestoreFailed"
-	Completed               = "Completed"
+	Created                  = ""
+	Started                  = "Started"
+	WaitOnResticRestart      = "WaitOnResticRestart"
+	ResticRestartCompleted   = "ResticRestartCompleted"
+	InitialBackupStarted     = "InitialBackupStarted"
+	InitialBackupCompleted   = "InitialBackupCompleted"
+	InitialBackupFailed      = "InitialBackupFailed"
+	StageBackupStarted       = "StageBackupStarted"
+	StageBackupCompleted     = "StageBackupCompleted"
+	StageBackupFailed        = "StageBackupFailed"
+	CreateStagePodsStarted   = "CreateStagePodsStarted"
+	CreateStagePodsCompleted = "CreateStagePodsCompleted"
+	WaitOnBackupReplication  = "WaitOnBackupReplication"
+	BackupReplicated         = "BackupReplicated"
+	StageRestoreStarted      = "StageRestoreStarted"
+	StageRestoreCompleted    = "StageRestoreCompleted"
+	StageRestoreFailed       = "StageRestoreFailed"
+	DeleteStagePodsStarted   = "DeleteStagePodsStarted"
+	DeleteStagePodsCompleted = "DeleteStagePodsCompleted"
+	FinalRestoreStarted      = "FinalRestoreStarted"
+	FinalRestoreCompleted    = "FinalRestoreCompleted"
+	FinalRestoreFailed       = "FinalRestoreFailed"
+	Completed                = "Completed"
 )
 
 var PhaseOrder = map[string]int{
-	Created:                 00, // 0-499 normal
-	Started:                 1,
-	WaitOnResticRestart:     10,
-	ResticRestartCompleted:  11,
-	BackupStarted:           20,
-	BackupCompleted:         21,
-	WaitOnBackupReplication: 30,
-	BackupReplicated:        31,
-	RestoreStarted:          40,
-	RestoreCompleted:        41,
-	BackupFailed:            501, // 500-999 errors
-	RestoreFailed:           510,
-	Completed:               1000, // Succeeded
+	Created:                  0, // 0-499 normal
+	Started:                  1,
+	WaitOnResticRestart:      10,
+	ResticRestartCompleted:   11,
+	InitialBackupStarted:     20,
+	InitialBackupCompleted:   21,
+	CreateStagePodsStarted:   30,
+	CreateStagePodsCompleted: 31,
+	StageBackupStarted:       32,
+	StageBackupCompleted:     33,
+	WaitOnBackupReplication:  40,
+	BackupReplicated:         41,
+	StageRestoreStarted:      50,
+	StageRestoreCompleted:    51,
+	DeleteStagePodsStarted:   52,
+	DeleteStagePodsCompleted: 53,
+	FinalRestoreStarted:      60,
+	FinalRestoreCompleted:    61,
+	InitialBackupFailed:      520, // 500-999 errors
+	StageBackupFailed:        530,
+	StageRestoreFailed:       550,
+	FinalRestoreFailed:       560,
+	Completed:                1000, // Succeeded
 }
 
 // Phase Error
@@ -165,8 +190,10 @@ type Task struct {
 	BackupResources []string
 	Phase           Phase
 	Errors          []string
-	Backup          *velero.Backup
-	Restore         *velero.Restore
+	InitialBackup   *velero.Backup
+	StageBackup     *velero.Backup
+	StageRestore    *velero.Restore
+	FinalRestore    *velero.Restore
 }
 
 // Reconcile() Example:
@@ -210,53 +237,127 @@ func (t *Task) Run() error {
 		return err
 	}
 
-	// Annotate persistent storage resources with actions
-	err = t.annotateStorageResources()
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-
 	// Return unless restic restart has finished
 	if t.Phase.Equals(Started) || t.Phase.Equals(WaitOnResticRestart) {
 		return nil
 	}
 
-	// Backup
-	err = t.ensureBackup()
+	// Run initial Backup if this is not a stage
+	// The initial backup captures the state of the applications on the source
+	// cluster while explicity setting `includePersistentVolumes` value to
+	// `false`. This will capture everything except PVs
+	if !t.stage() {
+		err = t.ensureInitialBackup()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		switch t.InitialBackup.Status.Phase {
+		case velero.BackupPhaseCompleted:
+			t.Phase.Set(InitialBackupCompleted)
+		case velero.BackupPhaseFailed:
+			reason := fmt.Sprintf(
+				"Backup: %s/%s failed.",
+				t.InitialBackup.Namespace,
+				t.InitialBackup.Name)
+			t.addErrors([]string{reason})
+			t.Phase.Set(InitialBackupFailed)
+			return nil
+		case velero.BackupPhasePartiallyFailed:
+			reason := fmt.Sprintf(
+				"Backup: %s/%s partially failed.",
+				t.InitialBackup.Namespace,
+				t.InitialBackup.Name)
+			t.addErrors([]string{reason})
+			t.Phase.Set(InitialBackupFailed)
+			return nil
+		case velero.BackupPhaseFailedValidation:
+			t.addErrors(t.InitialBackup.Status.ValidationErrors)
+			t.Phase.Set(InitialBackupFailed)
+			return nil
+		default:
+			t.Phase.Set(InitialBackupStarted)
+			return nil
+		}
+	}
+
+	t.Phase.Set(InitialBackupCompleted)
+
+	// Annotate persistent storage resources with PV actions
+	// This will also return the number of pods we have annotated to be backed up
+	// by restic. This is useful for knowing whether or not we need to create
+	// staging pods
+	err, resticAnnotationCount := t.annotateStorageResources()
 	if err != nil {
 		log.Trace(err)
 		return err
 	}
-	switch t.Backup.Status.Phase {
+
+	// Check if stage pods are created and running
+	created, err := t.areStagePodsCreated(resticAnnotationCount)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+
+	// If all stage pods are created and running OR there are no stage pods we
+	// need to create, continue
+	if created {
+		t.Phase.Set(CreateStagePodsCompleted)
+	} else if t.Owner.Annotations["openshift.io/stage-completed"] == "" {
+		t.Phase.Set(CreateStagePodsStarted)
+		// Swap out all copy pods with stage pods
+		err = t.createStagePods()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		return nil
+	}
+
+	// Scale down all owning resources
+	if t.quiesce() {
+		err = t.quiesceApplications()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+	}
+
+	// Run second backup to copy PV data
+	err = t.ensureStageBackup()
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+
+	switch t.StageBackup.Status.Phase {
 	case velero.BackupPhaseCompleted:
-		t.Phase.Set(BackupCompleted)
+		t.Phase.Set(StageBackupCompleted)
 	case velero.BackupPhaseFailed:
 		reason := fmt.Sprintf(
 			"Backup: %s/%s failed.",
-			t.Backup.Namespace,
-			t.Backup.Name)
+			t.StageBackup.Namespace,
+			t.StageBackup.Name)
 		t.addErrors([]string{reason})
-		t.Phase.Set(BackupFailed)
+		t.Phase.Set(StageBackupFailed)
 		return nil
 	case velero.BackupPhasePartiallyFailed:
 		reason := fmt.Sprintf(
 			"Backup: %s/%s partially failed.",
-			t.Backup.Namespace,
-			t.Backup.Name)
+			t.StageBackup.Namespace,
+			t.StageBackup.Name)
 		t.addErrors([]string{reason})
-		t.Phase.Set(BackupFailed)
+		t.Phase.Set(StageBackupFailed)
 		return nil
 	case velero.BackupPhaseFailedValidation:
-		t.addErrors(t.Backup.Status.ValidationErrors)
-		t.Phase.Set(BackupFailed)
+		t.addErrors(t.StageBackup.Status.ValidationErrors)
+		t.Phase.Set(StageBackupFailed)
 		return nil
 	default:
-		t.Phase.Set(BackupStarted)
+		t.Phase.Set(StageBackupStarted)
 		return nil
 	}
-
-	t.Phase.Set(BackupCompleted)
 
 	// Delete storage annotations
 	err = t.removeStorageResourceAnnotations()
@@ -267,60 +368,107 @@ func (t *Task) Run() error {
 
 	// Wait on Backup replication.
 	t.Phase.Set(WaitOnBackupReplication)
-	backup, err := t.getReplicatedBackup()
+	backupReplicated, err := t.areBackupsReplicated()
 	if err != nil {
 		log.Trace(err)
 		return err
 	}
-	if backup != nil {
-		t.Phase.Set(BackupReplicated)
-	} else {
+	if !backupReplicated {
 		return nil
 	}
+	t.Phase.Set(BackupReplicated)
 
-	// Restore
-	err = t.ensureRestore()
+	// Stage restore
+	err = t.ensureStageRestore()
 	if err != nil {
 		log.Trace(err)
 		return err
 	}
-	switch t.Restore.Status.Phase {
+
+	switch t.StageRestore.Status.Phase {
 	case velero.RestorePhaseCompleted:
-		t.Phase.Set(RestoreCompleted)
+		t.Phase.Set(StageRestoreCompleted)
 	case velero.RestorePhaseFailedValidation:
-		t.addErrors(t.Restore.Status.ValidationErrors)
-		t.Phase.Set(RestoreFailed)
+		t.addErrors(t.StageRestore.Status.ValidationErrors)
+		t.Phase.Set(StageRestoreFailed)
 		return nil
 	case velero.RestorePhaseFailed:
 		reason := fmt.Sprintf(
 			"Restore: %s/%s failed.",
-			t.Restore.Namespace,
-			t.Restore.Name)
+			t.StageRestore.Namespace,
+			t.StageRestore.Name)
 		t.addErrors([]string{reason})
-		t.Phase.Set(RestoreFailed)
+		t.Phase.Set(StageRestoreFailed)
 		return nil
 	case velero.RestorePhasePartiallyFailed:
 		reason := fmt.Sprintf(
 			"Restore: %s/%s partially failed.",
-			t.Restore.Namespace,
-			t.Restore.Name)
+			t.StageRestore.Namespace,
+			t.StageRestore.Name)
 		t.addErrors([]string{reason})
-		t.Phase.Set(RestoreFailed)
+		t.Phase.Set(StageRestoreFailed)
 		return nil
 	default:
-		t.Phase.Set(RestoreStarted)
+		t.Phase.Set(StageRestoreStarted)
 		return nil
 	}
-	t.Phase.Set(RestoreCompleted)
+	t.Phase.Set(StageRestoreCompleted)
 
-	// Delete stage Pods
-	if t.stage() {
-		err = t.deleteStagePods()
+	deleted, err := t.areStagePodsDeleted()
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+
+	if deleted {
+		t.Phase.Set(DeleteStagePodsCompleted)
+	} else {
+		t.Phase.Set(DeleteStagePodsStarted)
+		// Remove staging pods on source and destination cluster
+		err = t.removeStagePods()
 		if err != nil {
 			log.Trace(err)
 			return err
 		}
+		return nil
 	}
+
+	// Final Restore if not a stage
+	if !t.stage() {
+		err = t.ensureFinalRestore()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		switch t.FinalRestore.Status.Phase {
+		case velero.RestorePhaseCompleted:
+			t.Phase.Set(FinalRestoreCompleted)
+		case velero.RestorePhaseFailedValidation:
+			t.addErrors(t.FinalRestore.Status.ValidationErrors)
+			t.Phase.Set(FinalRestoreFailed)
+			return nil
+		case velero.RestorePhasePartiallyFailed:
+			reason := fmt.Sprintf(
+				"Restore: %s/%s partially failed.",
+				t.FinalRestore.Namespace,
+				t.FinalRestore.Name)
+			t.addErrors([]string{reason})
+			t.Phase.Set(FinalRestoreFailed)
+			return nil
+		case velero.RestorePhaseFailed:
+			reason := fmt.Sprintf(
+				"Restore: %s/%s failed.",
+				t.FinalRestore.Namespace,
+				t.FinalRestore.Name)
+			t.addErrors([]string{reason})
+			t.Phase.Set(FinalRestoreFailed)
+			return nil
+		default:
+			t.Phase.Set(FinalRestoreStarted)
+			return nil
+		}
+	}
+	t.Phase.Set(FinalRestoreCompleted)
 
 	// Done
 	t.Phase.Set(Completed)
@@ -375,11 +523,11 @@ func (t *Task) logExit() {
 	}
 	backup := ""
 	restore := ""
-	if t.Backup != nil {
-		backup = t.Backup.Name
+	if t.InitialBackup != nil {
+		backup = t.InitialBackup.Name
 	}
-	if t.Restore != nil {
-		restore = t.Restore.Name
+	if t.FinalRestore != nil {
+		restore = t.FinalRestore.Name
 	}
 	t.Log.Info(
 		"Migration: waiting.",
@@ -397,4 +545,92 @@ func (t *Task) addErrors(errors []string) {
 	for _, error := range errors {
 		t.Errors = append(t.Errors, error)
 	}
+}
+
+// Remove stage pods on source and destination cluster
+func (t *Task) removeStagePods() error {
+	srcClient, err := t.getSourceClient()
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	destClient, err := t.getDestinationClient()
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	// Find all stage pods
+	uniqueBackupLabelKey := fmt.Sprintf("%s-%s-copy", pvBackupLabelKey, t.Owner.UID)
+	labelSelector := map[string]string{
+		uniqueBackupLabelKey: "true",
+	}
+	options := k8sclient.MatchingLabels(labelSelector)
+	podList := corev1.PodList{}
+	err = srcClient.List(context.TODO(), options, &podList)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	for _, pod := range podList.Items {
+		err = srcClient.Delete(
+			context.TODO(),
+			&pod)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+	}
+	podList = corev1.PodList{}
+	err = destClient.List(context.TODO(), options, &podList)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	for _, pod := range podList.Items {
+		err = destClient.Delete(
+			context.TODO(),
+			&pod)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t *Task) areStagePodsDeleted() (bool, error) {
+	srcClient, err := t.getSourceClient()
+	if err != nil {
+		return false, err
+	}
+	destClient, err := t.getDestinationClient()
+	if err != nil {
+		return false, err
+	}
+	uniqueBackupLabelKey := fmt.Sprintf("%s-%s-copy", pvBackupLabelKey, t.Owner.UID)
+	labelSelector := map[string]string{
+		uniqueBackupLabelKey: "true",
+	}
+	options := k8sclient.MatchingLabels(labelSelector)
+	podList := corev1.PodList{}
+	// Find all stage pods on source cluster
+	err = srcClient.List(context.TODO(), options, &podList)
+	if err != nil {
+		return false, err
+	}
+	if len(podList.Items) != 0 {
+		return false, nil
+	}
+	// Reset podlist
+	podList = corev1.PodList{}
+	err = destClient.List(context.TODO(), options, &podList)
+	if err != nil {
+		return false, err
+	}
+	if len(podList.Items) != 0 {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -284,6 +284,18 @@ func (t *Task) Run() error {
 
 	t.Phase.Set(InitialBackupCompleted)
 
+	// Wait on Backup replication.
+	t.Phase.Set(WaitOnBackupReplication)
+	backupReplicated, err := t.areBackupsReplicated(true)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	if !backupReplicated {
+		return nil
+	}
+	t.Phase.Set(BackupReplicated)
+
 	// Annotate persistent storage resources with PV actions
 	// This will also return the number of pods we have annotated to be backed up
 	// by restic. This is useful for knowing whether or not we need to create
@@ -373,7 +385,7 @@ func (t *Task) Run() error {
 
 		// Wait on Backup replication.
 		t.Phase.Set(WaitOnBackupReplication)
-		backupReplicated, err := t.areBackupsReplicated()
+		backupReplicated, err := t.areBackupsReplicated(false)
 		if err != nil {
 			log.Trace(err)
 			return err


### PR DESCRIPTION
Fixes problems with stateless migrations. 

Current workflow creates empty backups when there are no staging pods created, the empty backups cause restores to fail on the destination. This PR skips the stage steps when there's no need (when there are no PVs to be migrated).