### PR TITLE
use new plugin repo

### DIFF
--- a/hack/deploy/manifests/20-velero-deployment.yaml
+++ b/hack/deploy/manifests/20-velero-deployment.yaml
@@ -63,7 +63,7 @@ spec:
         - name: scratch
           emptyDir: {}
       initContainers:
-        - image: quay.io/ocpmigrate/velero-plugin:latest
+        - image: quay.io/ocpmigrate/migration-plugin:latest
           imagePullPolicy: Always
           name: velero-plugin
           resources: {}


### PR DESCRIPTION
The github repo for the velero plugin has been split into two repositories:
1) a general-purpose backup/restore velero plugin for openshift workloads
2) a migration-specific plugin, used by the controller which includes 1)

The old plugin image location ( quay.io/ocpmigrate/velero-plugin ) will
be the general-purpose plugin, and  quay.io/ocpmigrate/migration-plugin
will be the migration plugin used by the controller.