### PR TITLE
Use velero deployed by mig-operator in the mig namespace

### DIFF
--- a/hack/deploy/deploy_velero.sh
+++ b/hack/deploy/deploy_velero.sh
@@ -21,7 +21,7 @@ echo
 echo "===================================================="
 echo "Adding privileged scc to velero service account"
 echo "===================================================="
-oc adm policy add-scc-to-user privileged system:serviceaccount:velero:velero
+oc adm policy add-scc-to-user privileged system:serviceaccount:mig:velero
 
 echo
 echo "=========="

--- a/hack/deploy/manifests/10-velero-crds.yaml
+++ b/hack/deploy/manifests/10-velero-crds.yaml
@@ -187,7 +187,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: velero
-  namespace: velero
+  namespace: mig
   labels:
     component: velero
 
@@ -200,7 +200,7 @@ metadata:
     component: velero
 subjects:
   - kind: ServiceAccount
-    namespace: velero
+    namespace: mig
     name: velero
 roleRef:
   kind: ClusterRole

--- a/hack/deploy/manifests/20-velero-deployment.yaml
+++ b/hack/deploy/manifests/20-velero-deployment.yaml
@@ -16,7 +16,7 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  namespace: velero
+  namespace: mig
   name: velero
 spec:
   replicas: 1

--- a/hack/deploy/manifests/30-restic-daemonset.yaml
+++ b/hack/deploy/manifests/30-restic-daemonset.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata: 
   name: restic
-  namespace: velero
+  namespace: mig
 spec:
   selector:
     matchLabels:

--- a/hack/deploy/manifests/60-cloud-credentials.yaml
+++ b/hack/deploy/manifests/60-cloud-credentials.yaml
@@ -4,5 +4,5 @@ data:
 kind: Secret
 metadata:
   name: cloud-credentials
-  namespace: velero
+  namespace: mig
 type: Opaque

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -591,7 +591,7 @@ func (r *MigPlan) GetCloudSecret(client k8sclient.Client) (*kapi.Secret, error) 
 const (
 	PvMoveAction    = "move"
 	PvCopyAction    = "copy"
-	VeleroNamespace = "velero"
+	VeleroNamespace = "mig"
 )
 
 // Name - The PV name.

--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -129,7 +129,7 @@ func (r *MigStorage) BuildBSL() *velero.BackupStorageLocation {
 	location := &velero.BackupStorageLocation{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:       r.GetCorrelationLabels(),
-			Namespace:    "velero",
+			Namespace:    VeleroNamespace,
 			GenerateName: r.Name + "-",
 		},
 		Spec: velero.BackupStorageLocationSpec{
@@ -204,7 +204,7 @@ func (r *MigStorage) BuildVSL() *velero.VolumeSnapshotLocation {
 	location := &velero.VolumeSnapshotLocation{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:       r.GetCorrelationLabels(),
-			Namespace:    "velero",
+			Namespace:    VeleroNamespace,
 			GenerateName: r.Name + "-",
 		},
 		Spec: velero.VolumeSnapshotLocationSpec{
@@ -250,7 +250,7 @@ func (r *MigStorage) BuildCloudSecret(client k8sclient.Client) (*kapi.Secret, er
 	secret := &kapi.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:    r.GetCorrelationLabels(),
-			Namespace: "velero",
+			Namespace: VeleroNamespace,
 			Name:      "cloud-credentials",
 		},
 	}


### PR DESCRIPTION
Our velero migration plugin makes velero unsuitable for use with generic velero backup/restore operations. Since this is the case we shouldn't expect there to be no current velero instance or no desire for a future velero instance to handle generic backup/restore operations in the velero namespace.