### PR TITLE
Improved migration controller with PV copy.

### DIFF
--- a/pkg/apis/migration/v1alpha1/condition.go
+++ b/pkg/apis/migration/v1alpha1/condition.go
@@ -36,6 +36,7 @@ const (
 // Status - The condition status.
 // Reason - The reason for the condition.
 // Message - The human readable description of the condition.
+// Durable - The condition not subject to staging.
 // staging - A condition has been explicitly set/updated.
 type Condition struct {
 	Type               string      `json:"type"`
@@ -44,6 +45,7 @@ type Condition struct {
 	Category           string      `json:"category"`
 	Message            string      `json:"message,omitempty"`
 	LastTransitionTime metav1.Time `json:"lastTransitionTime"`
+	Durable            bool        `json:"durable,omitempty"`
 	staged             bool
 }
 
@@ -99,7 +101,7 @@ func (r *Conditions) BeginStagingConditions() {
 	}
 	for index := range r.List {
 		condition := &r.List[index]
-		condition.staged = false
+		condition.staged = condition.Durable
 	}
 }
 

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -1,0 +1,376 @@
+package migmigration
+
+import (
+	"context"
+	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+)
+
+// Velero Plugin Annotations
+const (
+	StageOrFinalAnnotation = "openshift.io/migrate-copy-phase"   // (stage|final)
+	PvActionAnnotation     = "openshift.io/migrate-type"         // (move|copy)
+	QuiesceAnnotation      = "openshift.io/migrate-quiesce-pods" // (true|false)
+)
+
+// Restic Annotations
+const (
+	ResticPvBackupAnnotation = "backup.velero.io/backup-volumes" // (true|false)
+)
+
+// Labels.
+const (
+	// Resources included in the stage backup.
+	// Referenced by the Backup.LabelSelector. The value is the Task.UID().
+	IncludedInStageBackupLabel = "migration-included-stage-backup"
+	// Designated as an `initial` Backup.
+	// The value is the Task.UID().
+	InitialBackupLabel = "migration-initial-backup"
+	// Designated as an `stage` Backup.
+	// The value is the Task.UID().
+	StageBackupLabel = "migration-stage-backup"
+	// Designated as an `stage` Restore.
+	// The value is the Task.UID().
+	StageRestoreLabel = "migration-stage-restore"
+	// Designated as a `final` Restore.
+	// The value is the Task.UID().
+	FinalRestoreLabel = "migration-final-restore"
+)
+
+// Add annotations and labels.
+// The PvActionAnnotation annotation is added to PV & PVC as needed by the velero plugin.
+// The ResticPvBackupAnnotation is added to Pods as needed by Restic.
+// The IncludedInStageBackupLabel label is added to Pods, PVs, PVCs and is referenced
+// by the velero.Backup label selector.
+// The IncludedInStageBackupLabel label is added to Namespaces to prevent the
+// velero.Backup from being empty which causes the Restore to fail.
+func (t *Task) annotateStageResources() error {
+	client, err := t.getSourceClient()
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	// Pods
+	err = t.annotatePods(client)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	// PV & PVCs
+	err = t.annotatePvs(client)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+
+	return nil
+}
+
+// Add annotations and labels to PVCs.
+// The PvActionAnnotation annotation is added to PVC as needed by the velero plugin.
+// The IncludedInStageBackupLabel label is added to Pods, PVs, PVCs and is referenced
+// by the velero.Backup label selector.
+func (t *Task) annotatePVCs(client k8sclient.Client, pod corev1.Pod) ([]string, error) {
+	volumes := []string{}
+	pvs := t.getPVs()
+	for _, pv := range pod.Spec.Volumes {
+		claim := pv.VolumeSource.PersistentVolumeClaim
+		if claim == nil {
+			continue
+		}
+		pvc := corev1.PersistentVolumeClaim{}
+		err := client.Get(
+			context.TODO(),
+			types.NamespacedName{
+				Namespace: pod.Namespace,
+				Name:      claim.ClaimName,
+			},
+			&pvc)
+		// PV action (move|copy) annotation needed by the velero plugin.
+		if pvc.Annotations == nil {
+			pvc.Annotations = make(map[string]string)
+		}
+		pvAction := findPVAction(pvs, pvc.Spec.VolumeName)
+		pvc.Annotations[PvActionAnnotation] = pvAction
+		// Add label used by stage backup label selector.
+		if pvc.Labels == nil {
+			pvc.Labels = make(map[string]string)
+		}
+		pvc.Labels[IncludedInStageBackupLabel] = t.UID()
+		// Add to Restic volume list.
+		if pvAction == migapi.PvCopyAction {
+			volumes = append(volumes, pv.Name)
+		}
+		// Update
+		err = client.Update(context.TODO(), &pvc)
+		if err != nil {
+			log.Trace(err)
+			return nil, err
+		}
+		log.Info(
+			"PVC annotations/labels added.",
+			"ns",
+			pvc.Namespace,
+			"name",
+			pvc.Name)
+	}
+
+	return volumes, nil
+}
+
+// Add annotations and labels to Pods.
+// The ResticPvBackupAnnotation is added to Pods as needed by Restic.
+// The IncludedInStageBackupLabel label is added to Pods, PVs, PVCs and is referenced
+// by the velero.Backup label selector.
+func (t *Task) annotatePods(client k8sclient.Client) error {
+	for _, ns := range t.namespaces() {
+		list := corev1.PodList{}
+		options := k8sclient.InNamespace(ns)
+		err := client.List(context.TODO(), options, &list)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		for _, pod := range list.Items {
+			if pod.Labels == nil {
+				pod.Labels = make(map[string]string)
+			}
+			// Skip stage pods.
+			cLabel, _ := t.Owner.GetCorrelationLabel()
+			if _, found := pod.Labels[cLabel]; found {
+				continue
+			}
+			// Skip stateless pods.
+			if len(pod.Spec.Volumes) == 0 {
+				continue
+			}
+			// Annotate PVCs.
+			volumes, err := t.annotatePVCs(client, pod)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+			if len(volumes) == 0 {
+				continue
+			}
+			// Restic annotation used to specify volumes.
+			if pod.Annotations == nil {
+				pod.Annotations = make(map[string]string)
+			}
+			pod.Annotations[ResticPvBackupAnnotation] = strings.Join(volumes, ",")
+			// Add label used by stage backup label selector.
+			if pod.Labels == nil {
+				pod.Labels = make(map[string]string)
+			}
+			pod.Labels[IncludedInStageBackupLabel] = t.UID()
+			// Update
+			err = client.Update(context.TODO(), &pod)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+			log.Info(
+				"Pod annotations/labels added.",
+				"ns",
+				pod.Namespace,
+				"name",
+				pod.Name)
+		}
+	}
+
+	return nil
+}
+
+// Add annotations and labels to PVs.
+// The PvActionAnnotation annotation is added to PVC as needed by the velero plugin.
+// The IncludedInStageBackupLabel label is added to Pods, PVs, PVCs and is referenced
+// by the velero.Backup label selector.
+func (t *Task) annotatePvs(client k8sclient.Client) error {
+	pvs := t.getPVs()
+	for _, pv := range pvs.List {
+		resource := corev1.PersistentVolume{}
+		err := client.Get(
+			context.TODO(),
+			types.NamespacedName{
+				Name: pv.Name,
+			},
+			&resource)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if resource.Annotations == nil {
+			resource.Annotations = make(map[string]string)
+		}
+		// PV action (move|copy) needed by the velero plugin.
+		resource.Annotations[PvActionAnnotation] = pv.Action
+		// Add label used by stage backup label selector.
+		if resource.Labels == nil {
+			resource.Labels = make(map[string]string)
+		}
+		resource.Labels[IncludedInStageBackupLabel] = t.UID()
+		// Update
+		err = client.Update(context.TODO(), &resource)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		log.Info(
+			"PV annotations/labels added.",
+			"name",
+			pv.Name)
+	}
+
+	return nil
+}
+
+// Delete temporary annotations and labels added.
+func (t *Task) deleteAnnotations() error {
+	clients, err := t.getBothClients()
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+
+	for _, client := range clients {
+		err = t.deletePVCAnnotations(client)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		err = t.deletePVAnnotations(client)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		err = t.deletePodAnnotations(client)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Delete Pod stage annotations and labels.
+func (t *Task) deletePodAnnotations(client k8sclient.Client) error {
+	for _, ns := range t.namespaces() {
+		options := k8sclient.InNamespace(ns)
+		podList := corev1.PodList{}
+		err := client.List(context.TODO(), options, &podList)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		for _, pod := range podList.Items {
+			needsUpdate := false
+			if pod.Annotations != nil {
+				if _, found := pod.Annotations[ResticPvBackupAnnotation]; found {
+					delete(pod.Annotations, ResticPvBackupAnnotation)
+					needsUpdate = true
+				}
+			}
+			if pod.Labels != nil {
+				if _, found := pod.Labels[IncludedInStageBackupLabel]; found {
+					delete(pod.Labels, IncludedInStageBackupLabel)
+					needsUpdate = true
+				}
+			}
+			if !needsUpdate {
+				continue
+			}
+			err = client.Update(context.TODO(), &pod)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+			log.Info(
+				"Pod annotations/labels removed.",
+				"ns",
+				pod.Namespace,
+				"name",
+				pod.Name)
+		}
+	}
+
+	return nil
+}
+
+// Delete PVC stage annotations and labels.
+func (t *Task) deletePVCAnnotations(client k8sclient.Client) error {
+	for _, ns := range t.namespaces() {
+		options := k8sclient.InNamespace(ns)
+		pvcList := corev1.PersistentVolumeClaimList{}
+		err := client.List(context.TODO(), options, &pvcList)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		for _, pvc := range pvcList.Items {
+			needsUpdate := false
+			if pvc.Annotations != nil {
+				if _, found := pvc.Annotations[PvActionAnnotation]; found {
+					delete(pvc.Annotations, PvActionAnnotation)
+					needsUpdate = true
+				}
+			}
+			if pvc.Labels != nil {
+				if _, found := pvc.Labels[IncludedInStageBackupLabel]; found {
+					delete(pvc.Labels, IncludedInStageBackupLabel)
+					needsUpdate = true
+				}
+			}
+			if !needsUpdate {
+				continue
+			}
+			err = client.Update(context.TODO(), &pvc)
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
+			log.Info(
+				"PVC annotations/labels removed.",
+				"ns",
+				pvc.Namespace,
+				"name",
+				pvc.Name)
+		}
+	}
+
+	return nil
+}
+
+// Delete PV stage annotations and labels.
+func (t *Task) deletePVAnnotations(client k8sclient.Client) error {
+	labels := map[string]string{
+		IncludedInStageBackupLabel: t.UID(),
+	}
+	options := k8sclient.MatchingLabels(labels)
+	pvcList := corev1.PersistentVolumeClaimList{}
+	err := client.List(context.TODO(), options, &pvcList)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	for _, pvc := range pvcList.Items {
+		delete(pvc.Labels, IncludedInStageBackupLabel)
+		delete(pvc.Annotations, PvActionAnnotation)
+		err = client.Update(context.TODO(), &pvc)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		log.Info(
+			"PVC annotations/labels removed.",
+			"ns",
+			pvc.Namespace,
+			"name",
+			pvc.Name)
+	}
+
+	return nil
+}

--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -3,119 +3,119 @@ package migmigration
 import (
 	"context"
 	"fmt"
-	"reflect"
-	"strconv"
-	"strings"
-	"time"
-
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	velero "github.com/heptio/velero/pkg/apis/velero/v1"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"reflect"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
 )
 
-var resticPodPrefix = "restic-"
-var rhel7ImageRef = "registry.access.redhat.com/rhel7"
-var stagePodSuffix = "stage-pod"
-
-// Ensure the initial backup on the source cluster has been created and has the
-// proper settings.
-func (t *Task) ensureInitialBackup() error {
+// Ensure the initial backup on the source cluster has been created
+// and has the proper settings.
+func (t *Task) ensureInitialBackup() (*velero.Backup, error) {
 	includeClusterResources := false
 	newBackup, err := t.buildBackup(&includeClusterResources)
 	if err != nil {
 		log.Trace(err)
-		return err
+		return nil, err
 	}
-	delete(newBackup.Annotations, migQuiesceAnnotationKey)
-	foundBackup, err := t.getBackup(false)
+	newBackup.Labels[InitialBackupLabel] = t.UID()
+	delete(newBackup.Annotations, QuiesceAnnotation)
+	foundBackup, err := t.getInitialBackup()
 	if err != nil {
 		log.Trace(err)
-		return err
+		return nil, err
 	}
 	if foundBackup == nil {
-		t.InitialBackup = newBackup
 		client, err := t.getSourceClient()
 		if err != nil {
 			log.Trace(err)
-			return err
+			return nil, err
 		}
 		err = client.Create(context.TODO(), newBackup)
 		if err != nil {
 			log.Trace(err)
-			return err
+			return nil, err
 		}
-		return nil
+		return newBackup, nil
 	}
-	t.InitialBackup = foundBackup
 	if !t.equalsBackup(newBackup, foundBackup) {
 		client, err := t.getSourceClient()
 		if err != nil {
 			log.Trace(err)
-			return err
+			return nil, err
 		}
 		t.updateBackup(foundBackup)
 		err = client.Update(context.TODO(), foundBackup)
 		if err != nil {
 			log.Trace(err)
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return foundBackup, nil
 }
 
-// Ensure the second backup on the source cluster has been created and has the
-// proper settings.
-func (t *Task) ensureStageBackup() error {
+// Get the initial backup on the source cluster.
+func (t *Task) getInitialBackup() (*velero.Backup, error) {
+	labels := t.Owner.GetCorrelationLabels()
+	labels[InitialBackupLabel] = t.UID()
+	return t.getBackup(labels)
+}
+
+// Ensure the second backup on the source cluster has been created and
+// has the proper settings.
+func (t *Task) ensureStageBackup() (*velero.Backup, error) {
 	newBackup, err := t.buildBackup(nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	uniqueBackupLabelKey := fmt.Sprintf("%s-%s", pvBackupLabelKey, t.Owner.UID)
 	labelSelector := metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			uniqueBackupLabelKey:                         "true",
-			fmt.Sprintf("%s-copy", uniqueBackupLabelKey): "true",
+			IncludedInStageBackupLabel: t.UID(),
 		},
 	}
-
-	// Set included resources to stage resources
+	newBackup.Labels[StageBackupLabel] = t.UID()
 	newBackup.Spec.IncludedResources = stagingResources
 	newBackup.Spec.LabelSelector = &labelSelector
-	foundBackup, err := t.getBackup(true)
+	foundBackup, err := t.getStageBackup()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if foundBackup == nil {
-		t.StageBackup = newBackup
 		client, err := t.getSourceClient()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		err = client.Create(context.TODO(), newBackup)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		return nil
+		return newBackup, nil
 	}
-	t.StageBackup = foundBackup
 	if !t.equalsBackup(newBackup, foundBackup) {
 		client, err := t.getSourceClient()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		err = client.Update(context.TODO(), foundBackup)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return foundBackup, nil
+}
+
+// Get the stage backup on the source cluster.
+func (t *Task) getStageBackup() (*velero.Backup, error) {
+	labels := t.Owner.GetCorrelationLabels()
+	labels[StageBackupLabel] = t.UID()
+	return t.getBackup(labels)
 }
 
 // Get whether the two Backups are equal.
@@ -129,13 +129,12 @@ func (t *Task) equalsBackup(a, b *velero.Backup) bool {
 }
 
 // Get an existing Backup on the source cluster.
-func (t Task) getBackup(copyBackup bool) (*velero.Backup, error) {
+func (t Task) getBackup(labels map[string]string) (*velero.Backup, error) {
 	client, err := t.getSourceClient()
 	if err != nil {
 		return nil, err
 	}
 	list := velero.BackupList{}
-	labels := t.Owner.GetCorrelationLabels()
 	err = client.List(
 		context.TODO(),
 		k8sclient.MatchingLabels(labels),
@@ -143,20 +142,42 @@ func (t Task) getBackup(copyBackup bool) (*velero.Backup, error) {
 	if err != nil {
 		return nil, err
 	}
-	for i, backup := range list.Items {
-		// Avoid nil annotation lookup
-		if backup.Annotations == nil {
-			backup.Annotations = make(map[string]string)
-		}
-		if backup.Annotations[copyBackupRestoreAnnotationKey] != "" && copyBackup {
-			return &list.Items[i], nil
-		}
-		if backup.Annotations[copyBackupRestoreAnnotationKey] == "" && !copyBackup {
-			return &list.Items[i], nil
-		}
+	if len(list.Items) > 0 {
+		return &list.Items[0], nil
 	}
 
 	return nil, nil
+}
+
+// Get whether a backup has completed on the source cluster.
+func (t Task) hasBackupCompleted(backup *velero.Backup) (bool, []string) {
+	completed := false
+	reasons := []string{}
+	switch backup.Status.Phase {
+	case velero.BackupPhaseCompleted:
+		completed = true
+	case velero.BackupPhaseFailed:
+		completed = true
+		reasons = append(
+			reasons,
+			fmt.Sprintf(
+				"Backup: %s/%s partially failed.",
+				backup.Namespace,
+				backup.Name))
+	case velero.BackupPhasePartiallyFailed:
+		completed = true
+		reasons = append(
+			reasons,
+			fmt.Sprintf(
+				"Backup: %s/%s partially failed.",
+				backup.Namespace,
+				backup.Name))
+	case velero.BackupPhaseFailedValidation:
+		reasons = backup.Status.ValidationErrors
+		completed = true
+	}
+
+	return completed, reasons
 }
 
 // Get the existing BackupStorageLocation on the source cluster.
@@ -207,11 +228,6 @@ func (t *Task) buildBackup(includeClusterResources *bool) (*velero.Backup, error
 		log.Trace(err)
 		return nil, err
 	}
-	// If includeClusterResources isn't set, this means it is the second backup,
-	// first restore to satisfy moving the persistent storage over
-	if includeClusterResources == nil {
-		annotations[copyBackupRestoreAnnotationKey] = "true"
-	}
 	backup := &velero.Backup{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:       t.Owner.GetCorrelationLabels(),
@@ -229,7 +245,6 @@ func (t *Task) buildBackup(includeClusterResources *bool) (*velero.Backup, error
 
 // Update a Backups as desired for the source cluster.
 func (t *Task) updateBackup(backup *velero.Backup) error {
-	namespaces := t.PlanResources.MigPlan.Spec.Namespaces
 	backupLocation, err := t.getBSL()
 	if err != nil {
 		log.Trace(err)
@@ -244,7 +259,7 @@ func (t *Task) updateBackup(backup *velero.Backup) error {
 		StorageLocation:         backupLocation.Name,
 		VolumeSnapshotLocations: []string{snapshotLocation.Name},
 		TTL:                     metav1.Duration{Duration: 720 * time.Hour},
-		IncludedNamespaces:      namespaces,
+		IncludedNamespaces:      t.namespaces(),
 		ExcludedNamespaces:      []string{},
 		IncludedResources:       t.BackupResources,
 		ExcludedResources:       []string{},
@@ -257,428 +272,28 @@ func (t *Task) updateBackup(backup *velero.Backup) error {
 	return nil
 }
 
-// Determine whether backups are replicated by velero on the destination
-// cluster.
-func (t *Task) areBackupsReplicated() (bool, error) {
+// Determine whether backups are replicated by velero on the destination cluster.
+func (t *Task) isBackupReplicated(backup *velero.Backup) (bool, error) {
 	client, err := t.getDestinationClient()
 	if err != nil {
 		return false, err
 	}
-	list := velero.BackupList{}
-	labels := t.Owner.GetCorrelationLabels()
-	err = client.List(
+	replicated := velero.Backup{}
+	err = client.Get(
 		context.TODO(),
-		k8sclient.MatchingLabels(labels),
-		&list)
-	if err != nil {
-		return false, err
-	}
-	// If this is stage we only need to wait for 1 backup to be replicated
-	if len(list.Items) == 1 && t.stage() {
-		return true, nil
-	}
-	// If this is not a stage, we need to find 2 backups before continuing
-	if len(list.Items) > 1 {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-// Delete the running restic pod in velero namespace
-// This function is used to get around mount propagation requirements
-func (t *Task) bounceResticPod() error {
-	// If restart already completed, return
-	if !t.Phase.Equals(WaitOnResticRestart) && !t.Phase.Equals(Started) {
-		return nil
-	} else if t.Phase.Equals(WaitOnResticRestart) {
-		t.Log.Info("Waiting for restic pod to be ready")
-	}
-
-	// Get client of source cluster
-	client, err := t.getSourceClient()
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-
-	// List all pods in velero namespace
-	list := corev1.PodList{}
-	err = client.List(
-		context.TODO(),
-		&k8sclient.ListOptions{
-			Namespace: migapi.VeleroNamespace,
+		types.NamespacedName{
+			Namespace: backup.Namespace,
+			Name:      backup.Name,
 		},
-		&list)
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-
-	// Loop through all pods in velero namespace
-	for _, pod := range list.Items {
-		if !strings.HasPrefix(pod.Name, resticPodPrefix) {
-			continue
-		}
-		// Check if pod is running
-		if pod.Status.Phase != corev1.PodRunning {
-			continue
-		}
-		// If restart already started, mark it as completed
-		if t.Phase.Equals(WaitOnResticRestart) {
-			t.Phase.Set(ResticRestartCompleted)
-			t.Log.Info("Restic pod successfully restarted")
-			return nil
-		}
-		// Delete pod since restart never started
-		t.Log.Info(
-			"Deleting restic pod",
-			"name",
-			pod.Name)
-		err = client.Delete(
-			context.TODO(),
-			&pod)
-		if err != nil {
-			log.Trace(err)
-			return err
-		}
-		t.Phase.Set(WaitOnResticRestart)
-		return nil
-	}
-
-	return nil
-}
-
-// Annotate all resources with PV action data
-// Return the number of copy pods so that we know if we need to create stage
-// pods
-func (t *Task) annotateStorageResources() (error, int) {
-	// Get client of source cluster
-	client, err := t.getSourceClient()
-	if err != nil {
-		log.Trace(err)
-		return err, 0
-	}
-	uniqueBackupLabelKey := fmt.Sprintf("%s-%s", pvBackupLabelKey, t.Owner.UID)
-	namespaces := t.PlanResources.MigPlan.Spec.Namespaces
-	pvs := t.PlanResources.MigPlan.Spec.PersistentVolumes
-	for _, pv := range pvs.List {
-		// Update PVs with their action
-		resource := corev1.PersistentVolume{}
-		err := client.Get(
-			context.TODO(),
-			types.NamespacedName{
-				Name: pv.Name,
-			},
-			&resource)
-		if err != nil {
-			log.Trace(err)
-			return err, 0
-		}
-		if resource.Annotations == nil {
-			resource.Annotations = make(map[string]string)
-		}
-		resource.Annotations[pvAnnotationKey] = pv.Action
-		if resource.Labels == nil {
-			resource.Labels = make(map[string]string)
-		}
-		resource.Labels[uniqueBackupLabelKey] = pvBackupLabelValue
-		client.Update(context.TODO(), &resource)
-	}
-
-	resticAnnotationCount := 0
-	for _, ns := range namespaces {
-		// Find all pods in our target namespaces
-		list := corev1.PodList{}
-		options := k8sclient.InNamespace(ns)
-		err = client.List(context.TODO(), options, &list)
-		if err != nil {
-			log.Trace(err)
-			return err, 0
-		}
-		// Loop through all pods to find all volume claims
-		for _, pod := range list.Items {
-			if pod.Labels == nil {
-				pod.Labels = make(map[string]string)
-			}
-			// Don't need to do this for staging pods. Adds unnecessary work
-			if pod.Labels[fmt.Sprintf("%s-copy", uniqueBackupLabelKey)] != "" {
-				continue
-			}
-
-			resticVolumes := []string{}
-			for _, volume := range pod.Spec.Volumes {
-				claim := volume.VolumeSource.PersistentVolumeClaim
-				if claim == nil {
-					continue
-				}
-				pvc := corev1.PersistentVolumeClaim{}
-				ref := types.NamespacedName{
-					Namespace: ns,
-					Name:      claim.ClaimName,
-				}
-				// Get PVC and update annotation
-				err = client.Get(context.TODO(), ref, &pvc)
-				if pvc.Annotations == nil {
-					pvc.Annotations = make(map[string]string)
-				}
-				pvName := pvc.Spec.VolumeName
-				action := findPVAction(pvs, pvName)
-				pvc.Annotations[pvAnnotationKey] = action
-				if pvc.Labels == nil {
-					pvc.Labels = make(map[string]string)
-				}
-				pvc.Labels[uniqueBackupLabelKey] = pvBackupLabelValue
-				pvc.Labels[fmt.Sprintf("%s-copy", uniqueBackupLabelKey)] = pvBackupLabelValue
-				err = client.Update(context.TODO(), &pvc)
-				if action == migapi.PvCopyAction {
-					resticVolumes = append(resticVolumes, volume.Name)
-				}
-			}
-			if len(resticVolumes) > 0 {
-				resticAnnotationCount += 1
-				if pod.Annotations == nil {
-					pod.Annotations = make(map[string]string)
-				}
-				pod.Annotations[resticPvBackupAnnotationKey] = strings.Join(resticVolumes[:], ",")
-				if pod.Labels == nil {
-					pod.Labels = make(map[string]string)
-				}
-				pod.Labels[uniqueBackupLabelKey] = pvBackupLabelValue
-				err = client.Update(context.TODO(), &pod)
-			}
-		}
-	}
-
-	return nil, resticAnnotationCount
-}
-
-func (t *Task) areStagePodsCreated(resticAnnotationCount int) (bool, error) {
-	client, err := t.getSourceClient()
-	if err != nil {
-		return false, err
-	}
-	// check if we have already created stage pods
-	// if so, return true
-	uniqueBackupLabelKey := fmt.Sprintf("%s-%s", pvBackupLabelKey, t.Owner.UID)
-	labelSelector := map[string]string{
-		fmt.Sprintf("%s-copy", uniqueBackupLabelKey): "true",
-	}
-	options := k8sclient.MatchingLabels(labelSelector)
-	podList := corev1.PodList{}
-	err = client.List(context.TODO(), options, &podList)
-	if err != nil {
-		return false, err
-	}
-	podCount := len(podList.Items)
-	// If there are no stage pods and resticAnnotationCount is zero, this means
-	// we have already quiesced the app so the stage pods were created
-	// previously. Do not recreate them so return true
-	if podCount == 0 && resticAnnotationCount == 0 {
+		&replicated)
+	if err == nil {
 		return true, nil
 	}
-	readyCount := 0
-	for _, pod := range podList.Items {
-		if pod.Status.Phase == corev1.PodRunning {
-			readyCount += 1
-		}
-	}
-	// Check if all pods are ready
-	if readyCount == podCount && podCount != 0 {
-		return true, nil
-	}
-	return false, nil
-}
-
-// addLabelsToNamespace adds labels to namespaces to force
-// Velero to include them in the second backup to avoid
-// creating an empty backup
-func (t *Task) addLabelsToNamespace() error {
-	client, err := t.getSourceClient()
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-	uniqueBackupLabelKey := fmt.Sprintf("%s-%s", pvBackupLabelKey, t.Owner.UID)
-	if len(t.PlanResources.MigPlan.Spec.Namespaces) > 0 {
-		namespace := t.PlanResources.MigPlan.Spec.Namespaces[0]
-		ref := types.NamespacedName{
-			Name: namespace,
-		}
-		foundNamespace := corev1.Namespace{}
-		err = client.Get(context.TODO(), ref, &foundNamespace)
-		if foundNamespace.Labels == nil {
-			foundNamespace.Labels = make(map[string]string)
-		}
-		foundNamespace.Labels[uniqueBackupLabelKey] = pvBackupLabelValue
-		foundNamespace.Labels[fmt.Sprintf("%s-copy", uniqueBackupLabelKey)] = "true"
-		err = client.Update(context.TODO(), &foundNamespace)
-	}
-	return nil
-}
-
-// removeLabelsFromNamespace removes temporary labels from namespace
-func (t *Task) removeLabelsFromNamespace() error {
-	client, err := t.getSourceClient()
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-	uniqueBackupLabelKey := fmt.Sprintf("%s-%s", pvBackupLabelKey, t.Owner.UID)
-	if len(t.PlanResources.MigPlan.Spec.Namespaces) > 0 {
-		namespace := t.PlanResources.MigPlan.Spec.Namespaces[0]
-		ref := types.NamespacedName{
-			Name: namespace,
-		}
-		foundNamespace := corev1.Namespace{}
-		err = client.Get(context.TODO(), ref, &foundNamespace)
-		if foundNamespace.Labels != nil {
-			delete(foundNamespace.Labels, uniqueBackupLabelKey)
-			delete(foundNamespace.Labels, fmt.Sprintf("%s-copy", uniqueBackupLabelKey))
-			err = client.Update(context.TODO(), &foundNamespace)
-		}
-	}
-	return nil
-}
-
-func (t *Task) createStagePods() error {
-	client, err := t.getSourceClient()
-	if err != nil {
-		log.Trace(err)
-		return err
+	if k8serrors.IsNotFound(err) {
+		err = nil
 	}
 
-	// Stage pods haven't been created yet, lets create them
-	uniqueBackupLabelKey := fmt.Sprintf("%s-%s", pvBackupLabelKey, t.Owner.UID)
-	labelSelector := map[string]string{
-		uniqueBackupLabelKey: pvBackupLabelValue,
-	}
-	options := k8sclient.MatchingLabels(labelSelector)
-	podList := corev1.PodList{}
-	err = client.List(context.TODO(), options, &podList)
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-	for _, pod := range podList.Items {
-		if pod.Annotations[resticPvBackupAnnotationKey] == "" {
-			continue
-		}
-		if strings.HasSuffix(pod.Name, stagePodSuffix) {
-			continue
-		}
-		resticVolumeNames := strings.Split(pod.Annotations[resticPvBackupAnnotationKey], ",")
-		stagePod := corev1.Pod{}
-		stagePod.Spec.Containers = []corev1.Container{}
-		stagePod.Spec.Volumes = []corev1.Volume{}
-		for _, volume := range resticVolumeNames {
-			for _, podVolume := range pod.Spec.Volumes {
-				if volume == podVolume.Name {
-					stagePod.Spec.Volumes = append(stagePod.Spec.Volumes, podVolume)
-				}
-			}
-		}
-		stagePod.Spec.Volumes = pod.Spec.Volumes
-		// Swap image ref, command, and args and create a new stage pod to be backed up
-		for i, c := range pod.Spec.Containers {
-			newContainer := corev1.Container{
-				Name:    fmt.Sprintf("sleep-%s", strconv.Itoa(i)),
-				Image:   rhel7ImageRef,
-				Command: []string{"sleep"},
-				Args:    []string{"infinity"},
-			}
-			newContainer.VolumeMounts = []corev1.VolumeMount{}
-			for _, vm := range c.VolumeMounts {
-				for _, resticVolume := range resticVolumeNames {
-					if resticVolume == vm.Name {
-						newContainer.VolumeMounts = append(newContainer.VolumeMounts, vm)
-					}
-				}
-			}
-			stagePod.Spec.Containers = append(stagePod.Spec.Containers, newContainer)
-		}
-		stagePod.Name = fmt.Sprintf("%s-%s", pod.Name, stagePodSuffix)
-		stagePod.Namespace = pod.Namespace
-		if stagePod.Labels == nil {
-			stagePod.Labels = make(map[string]string)
-		}
-		stagePod.Labels[uniqueBackupLabelKey] = "true"
-		stagePod.Labels[fmt.Sprintf("%s-copy", uniqueBackupLabelKey)] = "true"
-		if stagePod.Annotations == nil {
-			stagePod.Annotations = make(map[string]string)
-		}
-		stagePod.Annotations[resticPvBackupAnnotationKey] = pod.Annotations[resticPvBackupAnnotationKey]
-		err = client.Create(context.TODO(), &stagePod)
-		// If we have already created the pod and it just isn't ready yet, we don't
-		// want to return an error
-		if k8serrors.IsAlreadyExists(err) {
-			return nil
-		} else if err != nil {
-			log.Trace(err)
-			return err
-		}
-	}
-	return nil
-}
-
-// Removes temporary annotations and labels used before backing up storage resources
-func (t *Task) removeStorageResourceAnnotations() error {
-	client, err := t.getSourceClient()
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-	uniqueBackupLabelKey := fmt.Sprintf("%s-%s", pvBackupLabelKey, t.Owner.UID)
-	labelSelector := map[string]string{
-		uniqueBackupLabelKey: pvBackupLabelValue,
-	}
-	pvcList := corev1.PersistentVolumeClaimList{}
-	options := k8sclient.MatchingLabels(labelSelector)
-	err = client.List(context.TODO(), options, &pvcList)
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-	for _, pvc := range pvcList.Items {
-		if pvc.Annotations != nil {
-			delete(pvc.Annotations, pvAnnotationKey)
-		}
-		if pvc.Labels != nil {
-			delete(pvc.Labels, uniqueBackupLabelKey)
-		}
-		err = client.Update(context.TODO(), &pvc)
-	}
-	pvList := corev1.PersistentVolumeList{}
-	err = client.List(context.TODO(), options, &pvList)
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-	for _, pv := range pvList.Items {
-		if pv.Annotations != nil {
-			delete(pv.Annotations, pvAnnotationKey)
-		}
-		if pv.Labels != nil {
-			delete(pv.Labels, uniqueBackupLabelKey)
-		}
-		err = client.Update(context.TODO(), &pv)
-	}
-	podList := corev1.PodList{}
-	err = client.List(context.TODO(), options, &podList)
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-	for _, pod := range podList.Items {
-		if pod.Annotations != nil {
-			delete(pod.Annotations, resticPvBackupAnnotationKey)
-		}
-		if pod.Labels != nil {
-			delete(pod.Labels, uniqueBackupLabelKey)
-		}
-		err = client.Update(context.TODO(), &pod)
-	}
-	return nil
+	return false, err
 }
 
 func findPVAction(pvList migapi.PersistentVolumes, pvName string) string {

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -23,24 +23,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Annotations
-const (
-	pvAnnotationKey             = "openshift.io/migrate-type"
-	migrateAnnotationValue      = "final"
-	migrateAnnotationKey        = "openshift.io/migrate-copy-phase"
-	stageAnnotationValue        = "stage"
-	stageAnnotationKey          = "openshift.io/migrate-copy-phase"
-	resticPvBackupAnnotationKey = "backup.velero.io/backup-volumes"
-)
-
-// Labels
-const (
-	pvBackupLabelKey   = "openshift.io/pv-backup"
-	pvBackupLabelValue = "true"
-)
-
 // Backup resources.
 var stagingResources = []string{
+	"namespaces",
 	"persistentvolumes",
 	"persistentvolumeclaims",
 	"imagestreams",
@@ -52,7 +37,7 @@ var stagingResources = []string{
 }
 
 // Perform the migration.
-func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (int, error) {
+func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (time.Duration, error) {
 	if migration.Status.HasAnyCondition(Succeeded, Failed) {
 		return 0, nil
 	}
@@ -85,7 +70,7 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (int, er
 		Client:          r,
 		Owner:           migration,
 		PlanResources:   planResources,
-		Phase:           Phase{Name: migration.Status.Phase},
+		Phase:           migration.Status.Phase,
 		Annotations:     r.getAnnotations(migration),
 		BackupResources: r.getBackupResources(migration),
 	}
@@ -95,52 +80,52 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (int, er
 		return 0, err
 	}
 
-	migration.Status.SetCondition(migapi.Condition{
-		Type:     Running,
-		Status:   True,
-		Reason:   task.Phase.Name,
-		Category: Advisory,
-		Message:  RunningMessage,
-	})
-
-	// TODO: SYNC WITH JEFF TO GET OPINION ON THIS HACK
-	// Setting this annotation to not create stage pods after copy restore has
-	// run to completion
-	if task.Phase.Equals(DeleteStagePodsStarted) {
-		if migration.Annotations == nil {
-			migration.Annotations = make(map[string]string)
-		}
-		migration.Annotations["openshift.io/stage-completed"] = "true"
-	}
-
 	// Result
-	migration.Status.Phase = task.Phase.Name
-	if task.Phase.Equals(WaitOnResticRestart) {
-		return 10, nil
-	}
-	if task.Phase.Final() {
+	migration.Status.Phase = task.Phase
+
+	// Succeeded
+	if task.Phase == Completed {
 		migration.Status.DeleteCondition(Running)
-		migration.Status.SetCondition(migapi.Condition{
-			Type:     Succeeded,
-			Status:   True,
-			Reason:   task.Phase.Name,
-			Category: Advisory,
-			Message:  SucceededMessage,
-		})
+		failed := task.Owner.Status.FindCondition(Failed)
+		if failed == nil {
+			migration.Status.SetCondition(migapi.Condition{
+				Type:     Succeeded,
+				Status:   True,
+				Reason:   task.Phase,
+				Category: Advisory,
+				Message:  SucceededMessage,
+				Durable:  true,
+			})
+		} else {
+			failed.Status = "True"
+		}
+		return task.Requeue, nil
 	}
-	if task.Phase.Failed() {
+	// Failed
+	if _, found := ErrorPhase[task.Phase]; found {
 		migration.AddErrors(task.Errors)
 		migration.Status.DeleteCondition(Running)
 		migration.Status.SetCondition(migapi.Condition{
 			Type:     Failed,
-			Status:   True,
-			Reason:   task.Phase.Name,
+			Status:   False,
+			Reason:   task.Phase,
 			Category: Critical,
 			Message:  FailedMessage,
+			Durable:  true,
 		})
+		return task.Requeue, nil
 	}
 
-	return 0, nil
+	// Running
+	migration.Status.SetCondition(migapi.Condition{
+		Type:     Running,
+		Status:   True,
+		Reason:   task.Phase,
+		Category: Advisory,
+		Message:  RunningMessage,
+	})
+
+	return task.Requeue, nil
 }
 
 // Get annotations.
@@ -151,9 +136,9 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (int, er
 func (r *ReconcileMigMigration) getAnnotations(migration *migapi.MigMigration) map[string]string {
 	annotations := make(map[string]string)
 	if migration.Spec.Stage {
-		annotations[stageAnnotationKey] = stageAnnotationValue
+		annotations[StageOrFinalAnnotation] = "stage"
 	} else {
-		annotations[migrateAnnotationKey] = migrateAnnotationValue
+		annotations[StageOrFinalAnnotation] = "final"
 	}
 	return annotations
 }

--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -1,0 +1,262 @@
+package migmigration
+
+import (
+	"context"
+	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	resticPodPrefix = "restic-"
+)
+
+// Delete the running restic pod.
+// Restarted to get around mount propagation requirements.
+func (t *Task) restartResticPod() error {
+	client, err := t.getSourceClient()
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	list := corev1.PodList{}
+	err = client.List(
+		context.TODO(),
+		&k8sclient.ListOptions{
+			Namespace: migapi.VeleroNamespace,
+		},
+		&list)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+
+	for _, pod := range list.Items {
+		if !strings.HasPrefix(pod.Name, resticPodPrefix) {
+			continue
+		}
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		err = client.Delete(
+			context.TODO(),
+			&pod)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		return nil
+	}
+
+	return nil
+}
+
+// Determine if restic pod is running.
+func (t *Task) hasResticPodStarted() (bool, error) {
+	client, err := t.getSourceClient()
+	if err != nil {
+		log.Trace(err)
+		return false, err
+	}
+	list := corev1.PodList{}
+	err = client.List(
+		context.TODO(),
+		&k8sclient.ListOptions{
+			Namespace: migapi.VeleroNamespace,
+		},
+		&list)
+	if err != nil {
+		log.Trace(err)
+		return false, err
+	}
+
+	for _, pod := range list.Items {
+		if !strings.HasPrefix(pod.Name, resticPodPrefix) {
+			continue
+		}
+		if pod.Status.Phase == corev1.PodRunning {
+			time.Sleep(time.Second * 3)
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// Build a stage pod based on `pod`.
+func (t *Task) buildStagePod(pod *corev1.Pod) *corev1.Pod {
+	labels := t.Owner.GetCorrelationLabels()
+	labels[IncludedInStageBackupLabel] = t.UID()
+
+	// Map of Restic volumes.
+	resticVolumes := map[string]bool{}
+	for _, name := range strings.Split(pod.Annotations[ResticPvBackupAnnotation], ",") {
+		resticVolumes[name] = true
+	}
+	// Base pod.
+	newPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pod.Namespace,
+			Name:      pod.Name + "-" + "stage",
+			Annotations: map[string]string{
+				ResticPvBackupAnnotation: pod.Annotations[ResticPvBackupAnnotation],
+			},
+			Labels: labels,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{},
+			Volumes:    []corev1.Volume{},
+		},
+	}
+	// Add volumes.
+	for _, volume := range pod.Spec.Volumes {
+		if _, found := resticVolumes[volume.Name]; found {
+			newPod.Spec.Volumes = append(newPod.Spec.Volumes, volume)
+		}
+	}
+	// Add containers.
+	for i, container := range pod.Spec.Containers {
+		stageContainer := corev1.Container{
+			Name:         "sleep-" + strconv.Itoa(i),
+			Image:        "registry.access.redhat.com/rhel7",
+			Command:      []string{"sleep"},
+			Args:         []string{"infinity"},
+			VolumeMounts: []corev1.VolumeMount{},
+		}
+		for _, mount := range container.VolumeMounts {
+			if _, found := resticVolumes[mount.Name]; found {
+				stageContainer.VolumeMounts = append(stageContainer.VolumeMounts, mount)
+			}
+		}
+		newPod.Spec.Containers = append(newPod.Spec.Containers, stageContainer)
+	}
+
+	return &newPod
+}
+
+// Ensure the stage pods have been created.
+func (t *Task) ensureStagePodsCreated() (int, error) {
+	count := 0
+	client, err := t.getSourceClient()
+	if err != nil {
+		log.Trace(err)
+		return 0, err
+	}
+
+	labelSelector := map[string]string{
+		IncludedInStageBackupLabel: t.UID(),
+	}
+	podList := corev1.PodList{}
+	options := k8sclient.MatchingLabels(labelSelector)
+	err = client.List(context.TODO(), options, &podList)
+	if err != nil {
+		log.Trace(err)
+		return 0, err
+	}
+	cLabel, _ := t.Owner.GetCorrelationLabel()
+	for _, pod := range podList.Items {
+		if _, found := pod.Annotations[ResticPvBackupAnnotation]; !found {
+			continue
+		}
+		// Skip stage pods.
+		if _, found := pod.Labels[cLabel]; found {
+			continue
+		}
+		// Create
+		count++
+		newPod := t.buildStagePod(&pod)
+		err = client.Create(context.TODO(), newPod)
+		if err == nil {
+			log.Info(
+				"Stage pod created.",
+				"ns",
+				pod.Namespace,
+				"name",
+				pod.Name)
+			delete(pod.Labels, IncludedInStageBackupLabel)
+			delete(pod.Annotations, ResticPvBackupAnnotation)
+			err = client.Update(context.TODO(), &pod)
+			if err != nil {
+				log.Trace(err)
+				return 0, err
+			}
+			continue
+		}
+		if !errors.IsAlreadyExists(err) {
+			log.Trace(err)
+			return 0, err
+		}
+	}
+	return count, nil
+}
+
+// Ensure the stage pods are Running.
+func (t *Task) ensureStagePodsStarted() (bool, error) {
+	client, err := t.getSourceClient()
+	if err != nil {
+		log.Trace(err)
+		return false, err
+	}
+
+	podList := corev1.PodList{}
+	options := k8sclient.MatchingLabels(t.Owner.GetCorrelationLabels())
+	err = client.List(context.TODO(), options, &podList)
+	if err != nil {
+		return false, err
+	}
+	for _, pod := range podList.Items {
+		if pod.Status.Phase != corev1.PodRunning {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// Ensure the stage pods have been deleted.
+func (t *Task) ensureStagePodsDeleted() error {
+	clients, err := t.getBothClients()
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	cLabel, _ := t.Owner.GetCorrelationLabel()
+	for _, client := range clients {
+		podList := corev1.PodList{}
+		for _, ns := range t.namespaces() {
+			options := k8sclient.InNamespace(ns)
+			err := client.List(context.TODO(), options, &podList)
+			if err != nil {
+				return err
+			}
+			for _, pod := range podList.Items {
+				// Owned by ANY migration.
+				if pod.Labels == nil {
+					continue
+				}
+				if _, found := pod.Labels[cLabel]; !found {
+					continue
+				}
+				// Delete
+				err := client.Delete(context.TODO(), &pod)
+				if err != nil && !errors.IsNotFound(err) {
+					log.Trace(err)
+					return err
+				}
+				log.Info(
+					"Stage pod deleted.",
+					"ns",
+					pod.Namespace,
+					"name",
+					pod.Name)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -175,9 +175,9 @@ func (t *Task) ensureStagePodsCreated() (int, error) {
 			log.Info(
 				"Stage pod created.",
 				"ns",
-				pod.Namespace,
+				newPod.Namespace,
 				"name",
-				pod.Name)
+				newPod.Name)
 			delete(pod.Labels, IncludedInStageBackupLabel)
 			delete(pod.Annotations, ResticPvBackupAnnotation)
 			err = client.Update(context.TODO(), &pod)

--- a/pkg/controller/migmigration/registry.go
+++ b/pkg/controller/migmigration/registry.go
@@ -44,7 +44,7 @@ func (t *Task) getAnnotations(client k8sclient.Client) (map[string]string, error
 		}
 	}
 	if t.quiesce() {
-		annotations[migQuiesceAnnotationKey] = "true"
+		annotations[QuiesceAnnotation] = "true"
 	}
 	return annotations, nil
 }

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -1,174 +1,58 @@
 package migmigration
 
 import (
-	"context"
-	"fmt"
-
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/go-logr/logr"
-	velero "github.com/heptio/velero/pkg/apis/velero/v1"
-	corev1 "k8s.io/api/core/v1"
+	"github.com/pkg/errors"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-// Annotation Keys
-const (
-	migQuiesceAnnotationKey        = "openshift.io/migrate-quiesce-pods"
-	copyBackupRestoreAnnotationKey = "openshift.io/copy-backup-restore"
+	"time"
 )
 
 // Phases
 const (
-	Created                  = ""
-	Started                  = "Started"
-	WaitOnResticRestart      = "WaitOnResticRestart"
-	ResticRestartCompleted   = "ResticRestartCompleted"
-	InitialBackupStarted     = "InitialBackupStarted"
-	InitialBackupCompleted   = "InitialBackupCompleted"
-	InitialBackupFailed      = "InitialBackupFailed"
-	StageBackupStarted       = "StageBackupStarted"
-	StageBackupCompleted     = "StageBackupCompleted"
-	StageBackupFailed        = "StageBackupFailed"
-	CreateStagePodsStarted   = "CreateStagePodsStarted"
-	CreateStagePodsCompleted = "CreateStagePodsCompleted"
-	WaitOnBackupReplication  = "WaitOnBackupReplication"
-	BackupReplicated         = "BackupReplicated"
-	StageRestoreStarted      = "StageRestoreStarted"
-	StageRestoreCompleted    = "StageRestoreCompleted"
-	StageRestoreFailed       = "StageRestoreFailed"
-	DeleteStagePodsStarted   = "DeleteStagePodsStarted"
-	DeleteStagePodsCompleted = "DeleteStagePodsCompleted"
-	FinalRestoreStarted      = "FinalRestoreStarted"
-	FinalRestoreCompleted    = "FinalRestoreCompleted"
-	FinalRestoreFailed       = "FinalRestoreFailed"
-	Completed                = "Completed"
+	Created                       = ""
+	Started                       = "Started"
+	Prepare                       = "Prepare"
+	EnsureInitialBackup           = "EnsureInitialBackup"
+	InitialBackupCreated          = "InitialBackupCreated"
+	InitialBackupFailed           = "InitialBackupFailed"
+	AnnotateResources             = "AnnotateResources"
+	EnsureStagePods               = "EnsureStagePods"
+	StagePodsCreated              = "StagePodsCreated"
+	RestartRestic                 = "RestartRestic"
+	ResticRestarted               = "ResticRestarted"
+	QuiesceApplications           = "QuiesceApplications"
+	EnsureStageBackup             = "EnsureStageBackup"
+	StageBackupCreated            = "StageBackupCreated"
+	StageBackupFailed             = "StageBackupFailed"
+	EnsureInitialBackupReplicated = "EnsureInitialBackupReplicated"
+	EnsureStageBackupReplicated   = "EnsureStageBackupReplicated"
+	EnsureStageRestore            = "EnsureStageRestore"
+	StageRestoreCreated           = "StageRestoreCreated"
+	StageRestoreFailed            = "StageRestoreFailed"
+	EnsureFinalRestore            = "EnsureFinalRestore"
+	FinalRestoreCreated           = "FinalRestoreCreated"
+	FinalRestoreFailed            = "FinalRestoreFailed"
+	EnsureStagePodsDeleted        = "EnsureStagePodsDeleted"
+	EnsureAnnotationsDeleted      = "EnsureAnnotationsDeleted"
+	Completed                     = "Completed"
 )
 
-var PhaseOrder = map[string]int{
-	Created:                  0, // 0-499 normal
-	Started:                  1,
-	WaitOnResticRestart:      10,
-	ResticRestartCompleted:   11,
-	InitialBackupStarted:     20,
-	InitialBackupCompleted:   21,
-	CreateStagePodsStarted:   30,
-	CreateStagePodsCompleted: 31,
-	StageBackupStarted:       32,
-	StageBackupCompleted:     33,
-	WaitOnBackupReplication:  40,
-	BackupReplicated:         41,
-	StageRestoreStarted:      50,
-	StageRestoreCompleted:    51,
-	DeleteStagePodsStarted:   52,
-	DeleteStagePodsCompleted: 53,
-	FinalRestoreStarted:      60,
-	FinalRestoreCompleted:    61,
-	InitialBackupFailed:      520, // 500-999 errors
-	StageBackupFailed:        530,
-	StageRestoreFailed:       550,
-	FinalRestoreFailed:       560,
-	Completed:                1000, // Succeeded
+// End phases.
+var EndPhase = map[string]bool{
+	InitialBackupFailed: true,
+	StageBackupFailed:   true,
+	FinalRestoreFailed:  true,
+	StageRestoreFailed:  true,
+	Completed:           true,
 }
 
-// Phase Error
-type PhaseNotValid struct {
-	Name string
-}
-
-func (p PhaseNotValid) Error() string {
-	return fmt.Sprintf("Phase %s not valid.", p.Name)
-}
-
-// Phase
-type Phase struct {
-	Name string
-}
-
-// Validate the phase.
-func (p *Phase) Validate() error {
-	_, found := PhaseOrder[p.Name]
-	if !found {
-		return &PhaseNotValid{Name: p.Name}
-	}
-
-	return nil
-}
-
-// Set the phase.
-// Prevents rewind or set to invalid value.
-func (p *Phase) Set(name string) {
-	if !p.Before(name) {
-		return
-	}
-	_, found := PhaseOrder[p.Name]
-	if !found {
-		log.Trace(&PhaseNotValid{Name: name})
-		return
-	}
-	p.Name = name
-}
-
-// Phase is equal.
-func (p Phase) Equals(other string) bool {
-	return p.Name == other
-}
-
-// Phase is after `other`.
-func (p Phase) After(other string) bool {
-	nA, found := PhaseOrder[p.Name]
-	if !found {
-		log.Trace(&PhaseNotValid{Name: p.Name})
-	}
-	nB, found := PhaseOrder[other]
-	if !found {
-		log.Trace(&PhaseNotValid{Name: other})
-	}
-	return nA > nB
-}
-
-// The `other` phase is done.
-// Same as p.Phase.Equals(other) || p.Phase.After(other)
-func (p Phase) EqAfter(other string) bool {
-	nA, found := PhaseOrder[p.Name]
-	if !found {
-		log.Trace(&PhaseNotValid{Name: p.Name})
-	}
-	nB, found := PhaseOrder[other]
-	if !found {
-		log.Trace(&PhaseNotValid{Name: other})
-	}
-	return nA >= nB
-}
-
-// Phase is before `other`.
-func (p Phase) Before(other string) bool {
-	nA, found := PhaseOrder[p.Name]
-	if !found {
-		log.Trace(&PhaseNotValid{Name: p.Name})
-	}
-	nB, found := PhaseOrder[other]
-	if !found {
-		log.Trace(&PhaseNotValid{Name: other})
-	}
-	return nA < nB
-}
-
-// Phase is final.
-func (p Phase) Final() bool {
-	n, found := PhaseOrder[p.Name]
-	if !found {
-		log.Trace(&PhaseNotValid{Name: p.Name})
-	}
-	return n >= 500
-}
-
-// Phase is final.
-func (p Phase) Failed() bool {
-	n, found := PhaseOrder[p.Name]
-	if !found {
-		log.Trace(&PhaseNotValid{Name: p.Name})
-	}
-	return n >= 500 && n < 1000
+// Error phases.
+var ErrorPhase = map[string]bool{
+	InitialBackupFailed: true,
+	StageBackupFailed:   true,
+	FinalRestoreFailed:  true,
+	StageRestoreFailed:  true,
 }
 
 // A Velero task that provides the complete backup & restore workflow.
@@ -179,9 +63,8 @@ func (p Phase) Failed() bool {
 // Annotations - Map of annotations to applied to the backup & restore
 // BackupResources - Resource types to be included in the backup.
 // Phase - The task phase.
+// Requeue - The requeueAfter duration. 0 indicates no requeue.
 // Errors - Migration errors.
-// Backup - A Backup created on the source cluster.
-// Restore - A Restore created on the destination cluster.
 type Task struct {
 	Log             logr.Logger
 	Client          k8sclient.Client
@@ -189,298 +72,371 @@ type Task struct {
 	PlanResources   *migapi.PlanResources
 	Annotations     map[string]string
 	BackupResources []string
-	Phase           Phase
+	Phase           string
+	Requeue         time.Duration
 	Errors          []string
-	InitialBackup   *velero.Backup
-	StageBackup     *velero.Backup
-	StageRestore    *velero.Restore
-	FinalRestore    *velero.Restore
 }
 
-// Reconcile() Example:
-//
-// task := Task{
-//     Log: log,
-//     Client: r,
-//     Owner: migration,
-//     PlanResources: plan.GetPlanResources(),
-// }
-//
-// err := task.Run()
-// switch task.Phase {
-//     case Complete:
-//         ...
-// }
-//
-
 // Run the task.
-// Return `true` when run to completion.
+// Each call will:
+//   1. Run the current phase.
+//   2. Update the phase to the next phase.
+//   3. Set the Requeue (as appropriate).
+//   4. Return.
 func (t *Task) Run() error {
-	t.logEnter()
-	defer t.logExit()
+	t.Log.Info(
+		"Migration [RUN]",
+		"name",
+		t.Owner.Name,
+		"stage",
+		t.stage(),
+		"phase",
+		t.Phase)
 
-	// Validate phase.
-	err := t.Phase.Validate()
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
+	t.Requeue = time.Millisecond * 100
 
-	// Started
-	t.Phase.Set(Started)
-
-	// Mount propagation workaround
-	// TODO: Only bounce restic pod if cluster version is 3.7-3.9,
-	// would require passing in cluster version to the controller.
-	err = t.bounceResticPod()
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-
-	// Return unless restic restart has finished
-	if t.Phase.Equals(Started) || t.Phase.Equals(WaitOnResticRestart) {
-		return nil
-	}
-
-	// forces velero to select namespaces as part of the backup
-	t.addLabelsToNamespace()
-
-	// Run initial Backup if this is not a stage
-	// The initial backup captures the state of the applications on the source
-	// cluster while explicity setting `includePersistentVolumes` value to
-	// `false`. This will capture everything except PVs
-	if !t.stage() {
-		err = t.ensureInitialBackup()
+	switch t.Phase {
+	case Created:
+		t.Phase = Started
+	case Started:
+		t.Phase = Prepare
+	case Prepare:
+		err := t.deleteAnnotations()
 		if err != nil {
 			log.Trace(err)
 			return err
 		}
-		switch t.InitialBackup.Status.Phase {
-		case velero.BackupPhaseCompleted:
-			t.Phase.Set(InitialBackupCompleted)
-		case velero.BackupPhaseFailed:
-			reason := fmt.Sprintf(
-				"Backup: %s/%s failed.",
-				t.InitialBackup.Namespace,
-				t.InitialBackup.Name)
-			t.addErrors([]string{reason})
-			t.Phase.Set(InitialBackupFailed)
-			return nil
-		case velero.BackupPhasePartiallyFailed:
-			reason := fmt.Sprintf(
-				"Backup: %s/%s partially failed.",
-				t.InitialBackup.Namespace,
-				t.InitialBackup.Name)
-			t.addErrors([]string{reason})
-			t.Phase.Set(InitialBackupFailed)
-			return nil
-		case velero.BackupPhaseFailedValidation:
-			t.addErrors(t.InitialBackup.Status.ValidationErrors)
-			t.Phase.Set(InitialBackupFailed)
-			return nil
-		default:
-			t.Phase.Set(InitialBackupStarted)
-			return nil
-		}
-	}
-
-	t.Phase.Set(InitialBackupCompleted)
-
-	// Annotate persistent storage resources with PV actions
-	// This will also return the number of pods we have annotated to be backed up
-	// by restic. This is useful for knowing whether or not we need to create
-	// staging pods
-	err, resticAnnotationCount := t.annotateStorageResources()
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-
-	// Check if stage pods are created and running
-	created, err := t.areStagePodsCreated(resticAnnotationCount)
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-
-	// If all stage pods are created and running OR there are no stage pods we
-	// need to create, continue
-	if created {
-		t.Phase.Set(CreateStagePodsCompleted)
-	} else if t.Owner.Annotations["openshift.io/stage-completed"] == "" {
-		t.Phase.Set(CreateStagePodsStarted)
-		// Swap out all copy pods with stage pods
-		err = t.createStagePods()
+		err = t.ensureStagePodsDeleted()
 		if err != nil {
 			log.Trace(err)
 			return err
 		}
-		return nil
-	}
-
-	// Scale down all owning resources
-	if t.quiesce() {
-		err = t.quiesceApplications()
+		if t.stage() {
+			if t.hasPVs() {
+				t.Phase = AnnotateResources
+			} else {
+				t.Phase = Completed
+			}
+		} else {
+			t.Phase = EnsureInitialBackup
+		}
+	case EnsureInitialBackup:
+		_, err := t.ensureInitialBackup()
 		if err != nil {
 			log.Trace(err)
 			return err
 		}
-	}
-
-	// Run second backup to copy PV data
-	err = t.ensureStageBackup()
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-
-	switch t.StageBackup.Status.Phase {
-	case velero.BackupPhaseCompleted:
-		t.Phase.Set(StageBackupCompleted)
-	case velero.BackupPhaseFailed:
-		reason := fmt.Sprintf(
-			"Backup: %s/%s failed.",
-			t.StageBackup.Namespace,
-			t.StageBackup.Name)
-		t.addErrors([]string{reason})
-		t.Phase.Set(StageBackupFailed)
-		return nil
-	case velero.BackupPhasePartiallyFailed:
-		reason := fmt.Sprintf(
-			"Backup: %s/%s partially failed.",
-			t.StageBackup.Namespace,
-			t.StageBackup.Name)
-		t.addErrors([]string{reason})
-		t.Phase.Set(StageBackupFailed)
-		return nil
-	case velero.BackupPhaseFailedValidation:
-		t.addErrors(t.StageBackup.Status.ValidationErrors)
-		t.Phase.Set(StageBackupFailed)
-		return nil
-	default:
-		t.Phase.Set(StageBackupStarted)
-		return nil
-	}
-
-	// Delete storage annotations
-	err = t.removeStorageResourceAnnotations()
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-
-	// Wait on Backup replication.
-	t.Phase.Set(WaitOnBackupReplication)
-	backupReplicated, err := t.areBackupsReplicated()
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-	if !backupReplicated {
-		return nil
-	}
-	t.Phase.Set(BackupReplicated)
-
-	// Stage restore
-	err = t.ensureStageRestore()
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-
-	switch t.StageRestore.Status.Phase {
-	case velero.RestorePhaseCompleted:
-		t.Phase.Set(StageRestoreCompleted)
-	case velero.RestorePhaseFailedValidation:
-		t.addErrors(t.StageRestore.Status.ValidationErrors)
-		t.Phase.Set(StageRestoreFailed)
-		return nil
-	case velero.RestorePhaseFailed:
-		reason := fmt.Sprintf(
-			"Restore: %s/%s failed.",
-			t.StageRestore.Namespace,
-			t.StageRestore.Name)
-		t.addErrors([]string{reason})
-		t.Phase.Set(StageRestoreFailed)
-		return nil
-	case velero.RestorePhasePartiallyFailed:
-		reason := fmt.Sprintf(
-			"Restore: %s/%s partially failed.",
-			t.StageRestore.Namespace,
-			t.StageRestore.Name)
-		t.addErrors([]string{reason})
-		t.Phase.Set(StageRestoreFailed)
-		return nil
-	default:
-		t.Phase.Set(StageRestoreStarted)
-		return nil
-	}
-	t.Phase.Set(StageRestoreCompleted)
-
-	deleted, err := t.areStagePodsDeleted()
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-
-	if deleted {
-		t.Phase.Set(DeleteStagePodsCompleted)
-	} else {
-		t.Phase.Set(DeleteStagePodsStarted)
-		// Remove staging pods on source and destination cluster
-		err = t.removeStagePods()
+		t.Phase = InitialBackupCreated
+		t.Requeue = 0
+	case InitialBackupCreated:
+		backup, err := t.ensureInitialBackup()
 		if err != nil {
 			log.Trace(err)
 			return err
 		}
-		return nil
-	}
-
-	// remove the labels added to source namespace
-	t.removeLabelsFromNamespace()
-
-	// Final Restore if not a stage
-	if !t.stage() {
-		err = t.ensureFinalRestore()
+		if backup == nil {
+			return errors.New("Backup not found")
+		}
+		completed, reasons := t.hasBackupCompleted(backup)
 		if err != nil {
 			log.Trace(err)
 			return err
 		}
-		switch t.FinalRestore.Status.Phase {
-		case velero.RestorePhaseCompleted:
-			t.Phase.Set(FinalRestoreCompleted)
-		case velero.RestorePhaseFailedValidation:
-			t.addErrors(t.FinalRestore.Status.ValidationErrors)
-			t.Phase.Set(FinalRestoreFailed)
-			return nil
-		case velero.RestorePhasePartiallyFailed:
-			reason := fmt.Sprintf(
-				"Restore: %s/%s partially failed.",
-				t.FinalRestore.Namespace,
-				t.FinalRestore.Name)
-			t.addErrors([]string{reason})
-			t.Phase.Set(FinalRestoreFailed)
-			return nil
-		case velero.RestorePhaseFailed:
-			reason := fmt.Sprintf(
-				"Restore: %s/%s failed.",
-				t.FinalRestore.Namespace,
-				t.FinalRestore.Name)
-			t.addErrors([]string{reason})
-			t.Phase.Set(FinalRestoreFailed)
-			return nil
-		default:
-			t.Phase.Set(FinalRestoreStarted)
-			return nil
+		if completed {
+			if len(reasons) > 0 {
+				t.addErrors(reasons)
+				t.Phase = InitialBackupFailed
+			} else {
+				if t.hasPVs() {
+					t.Phase = AnnotateResources
+				} else {
+					t.Phase = EnsureInitialBackupReplicated
+				}
+			}
+		} else {
+			t.Requeue = 0
 		}
+	case AnnotateResources:
+		err := t.annotateStageResources()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		t.Phase = EnsureStagePods
+	case EnsureStagePods:
+		count, err := t.ensureStagePodsCreated()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if count > 0 {
+			t.Phase = StagePodsCreated
+			t.Requeue = 0
+		} else {
+			if t.quiesce() {
+				t.Phase = QuiesceApplications
+			} else {
+				t.Phase = EnsureStageBackup
+			}
+		}
+	case StagePodsCreated:
+		started, err := t.ensureStagePodsStarted()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if started {
+			t.Phase = RestartRestic
+		} else {
+			t.Requeue = 0
+		}
+	case RestartRestic:
+		err := t.restartResticPod()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		t.Phase = ResticRestarted
+	case ResticRestarted:
+		started, err := t.hasResticPodStarted()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if started {
+			if t.quiesce() {
+				t.Phase = QuiesceApplications
+			} else {
+				t.Phase = EnsureStageBackup
+			}
+		} else {
+			t.Requeue = time.Second * 3
+		}
+	case QuiesceApplications:
+		err := t.quiesceApplications()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		t.Phase = EnsureStageBackup
+	case EnsureStageBackup:
+		_, err := t.ensureStageBackup()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		t.Phase = StageBackupCreated
+		t.Requeue = 0
+	case StageBackupCreated:
+		backup, err := t.ensureStageBackup()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if backup == nil {
+			return errors.New("Backup not found")
+		}
+		completed, reasons := t.hasBackupCompleted(backup)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if completed {
+			if len(reasons) > 0 {
+				t.addErrors(reasons)
+				t.Phase = StageBackupFailed
+			} else {
+				t.Phase = EnsureStageBackupReplicated
+			}
+		} else {
+			t.Requeue = 0
+		}
+	case EnsureStageBackupReplicated:
+		backup, err := t.getStageBackup()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if backup == nil {
+			return errors.New("Backup not found")
+		}
+		replicated, err := t.isBackupReplicated(backup)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if replicated {
+			if t.stage() {
+				t.Phase = EnsureStageRestore
+			} else {
+				t.Phase = EnsureStageRestore
+			}
+		} else {
+			t.Requeue = 0
+		}
+	case EnsureStageRestore:
+		backup, err := t.getStageBackup()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if backup == nil {
+			return errors.New("Backup not found")
+		}
+		_, err = t.ensureStageRestore()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		t.Phase = StageRestoreCreated
+		t.Requeue = 0
+	case StageRestoreCreated:
+		restore, err := t.ensureStageRestore()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if restore == nil {
+			return errors.New("Restore not found")
+		}
+		completed, reasons := t.hasRestoreCompleted(restore)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if completed {
+			if len(reasons) > 0 {
+				t.addErrors(reasons)
+				t.Phase = StageRestoreFailed
+			} else {
+				t.Phase = EnsureStagePodsDeleted
+			}
+		} else {
+			t.Requeue = 0
+		}
+	case EnsureStagePodsDeleted:
+		err := t.ensureStagePodsDeleted()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		t.Phase = EnsureAnnotationsDeleted
+	case EnsureAnnotationsDeleted:
+		err := t.deleteAnnotations()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if t.stage() {
+			t.Phase = Completed
+		} else {
+			t.Phase = EnsureInitialBackupReplicated
+		}
+	case EnsureInitialBackupReplicated:
+		backup, err := t.getInitialBackup()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if backup == nil {
+			return errors.New("Backup not found")
+		}
+		replicated, err := t.isBackupReplicated(backup)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if replicated {
+			t.Phase = EnsureFinalRestore
+		} else {
+			t.Requeue = 0
+		}
+	case EnsureFinalRestore:
+		backup, err := t.getInitialBackup()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if backup == nil {
+			return errors.New("Backup not found")
+		}
+		_, err = t.ensureFinalRestore()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		t.Phase = FinalRestoreCreated
+		t.Requeue = 0
+	case FinalRestoreCreated:
+		restore, err := t.ensureFinalRestore()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if restore == nil {
+			return errors.New("Restore not found")
+		}
+		completed, reasons := t.hasRestoreCompleted(restore)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		if completed {
+			if len(reasons) > 0 {
+				t.addErrors(reasons)
+				t.Phase = FinalRestoreFailed
+			} else {
+				t.Phase = Completed
+			}
+		} else {
+			t.Requeue = 0
+		}
+	case StageBackupFailed, StageRestoreFailed:
+		err := t.deleteAnnotations()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		err = t.ensureStagePodsDeleted()
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		t.Phase = Completed
+	case InitialBackupFailed, FinalRestoreFailed:
+		t.Phase = Completed
+	case Completed:
+		t.Requeue = 0
 	}
-	t.Phase.Set(FinalRestoreCompleted)
 
-	// Done
-	t.Phase.Set(Completed)
+	if t.Phase == Completed {
+		t.Log.Info(
+			"Migration [COMPLETED]",
+			"name",
+			t.Owner.Name)
+	}
 
 	return nil
+}
+
+// Migration UID.
+func (t *Task) UID() string {
+	return string(t.Owner.UID)
+}
+
+// Get whether the migration is stage.
+func (t *Task) stage() bool {
+	return t.Owner.Spec.Stage
+}
+
+// Get the migration namespaces.
+func (t *Task) namespaces() []string {
+	return t.PlanResources.MigPlan.Spec.Namespaces
+}
+
+// Get whether to quiesce pods.
+func (t *Task) quiesce() bool {
+	return t.Owner.Spec.QuiescePods
 }
 
 // Get a client for the source cluster.
@@ -493,58 +449,35 @@ func (t *Task) getDestinationClient() (k8sclient.Client, error) {
 	return t.PlanResources.DestMigCluster.GetClient(t.Client)
 }
 
-// Get whether the migration is stage.
-func (t *Task) stage() bool {
-	return t.Owner.Spec.Stage
+// Get the persistent volumes included in the plan.
+func (t *Task) getPVs() migapi.PersistentVolumes {
+	return t.PlanResources.MigPlan.Spec.PersistentVolumes
 }
 
-// Get whether to quiesce pods.
-func (t *Task) quiesce() bool {
-	return t.Owner.Spec.QuiescePods
+// Get whether the associated plan lists any PVs.
+func (t *Task) hasPVs() bool {
+	return len(t.getPVs().List) > 0
 }
 
-// Log task start/resumed.
-func (t *Task) logEnter() {
-	if t.Phase.Equals(Started) {
-		t.Log.Info(
-			"Migration: started.",
-			"name",
-			t.Owner.Name,
-			"stage",
-			t.stage())
-		return
+// Get both source and destination clients.
+func (t *Task) getBothClients() ([]k8sclient.Client, error) {
+	list := []k8sclient.Client{}
+	// Source
+	client, err := t.getSourceClient()
+	if err != nil {
+		log.Trace(err)
+		return nil, err
 	}
-	t.Log.Info(
-		"Migration: resumed.",
-		"name",
-		t.Owner.Name,
-		"phase",
-		t.Phase)
-}
+	list = append(list, client)
+	// Destination
+	client, err = t.getDestinationClient()
+	if err != nil {
+		log.Trace(err)
+		return nil, err
+	}
+	list = append(list, client)
 
-// Log task exit/interrupted.
-func (t *Task) logExit() {
-	if t.Phase.Equals(Completed) {
-		t.Log.Info("Migration completed.")
-		return
-	}
-	backup := ""
-	restore := ""
-	if t.InitialBackup != nil {
-		backup = t.InitialBackup.Name
-	}
-	if t.FinalRestore != nil {
-		restore = t.FinalRestore.Name
-	}
-	t.Log.Info(
-		"Migration: waiting.",
-		"name",
-		t.Owner.Name,
-		"phase", t.Phase,
-		"backup",
-		backup,
-		"restore",
-		restore)
+	return list, nil
 }
 
 // Add errors.
@@ -552,92 +485,4 @@ func (t *Task) addErrors(errors []string) {
 	for _, error := range errors {
 		t.Errors = append(t.Errors, error)
 	}
-}
-
-// Remove stage pods on source and destination cluster
-func (t *Task) removeStagePods() error {
-	srcClient, err := t.getSourceClient()
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-	destClient, err := t.getDestinationClient()
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-	// Find all stage pods
-	uniqueBackupLabelKey := fmt.Sprintf("%s-%s-copy", pvBackupLabelKey, t.Owner.UID)
-	labelSelector := map[string]string{
-		uniqueBackupLabelKey: "true",
-	}
-	options := k8sclient.MatchingLabels(labelSelector)
-	podList := corev1.PodList{}
-	err = srcClient.List(context.TODO(), options, &podList)
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-	for _, pod := range podList.Items {
-		err = srcClient.Delete(
-			context.TODO(),
-			&pod)
-		if err != nil {
-			log.Trace(err)
-			return err
-		}
-	}
-	podList = corev1.PodList{}
-	err = destClient.List(context.TODO(), options, &podList)
-	if err != nil {
-		log.Trace(err)
-		return err
-	}
-	for _, pod := range podList.Items {
-		err = destClient.Delete(
-			context.TODO(),
-			&pod)
-		if err != nil {
-			log.Trace(err)
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (t *Task) areStagePodsDeleted() (bool, error) {
-	srcClient, err := t.getSourceClient()
-	if err != nil {
-		return false, err
-	}
-	destClient, err := t.getDestinationClient()
-	if err != nil {
-		return false, err
-	}
-	uniqueBackupLabelKey := fmt.Sprintf("%s-%s-copy", pvBackupLabelKey, t.Owner.UID)
-	labelSelector := map[string]string{
-		uniqueBackupLabelKey: "true",
-	}
-	options := k8sclient.MatchingLabels(labelSelector)
-	podList := corev1.PodList{}
-	// Find all stage pods on source cluster
-	err = srcClient.List(context.TODO(), options, &podList)
-	if err != nil {
-		return false, err
-	}
-	if len(podList.Items) != 0 {
-		return false, nil
-	}
-	// Reset podlist
-	podList = corev1.PodList{}
-	err = destClient.List(context.TODO(), options, &podList)
-	if err != nil {
-		return false, err
-	}
-	if len(podList.Items) != 0 {
-		return false, nil
-	}
-
-	return true, nil
 }


### PR DESCRIPTION
Overview
---
The functionality added to the migration controller needed to support PV copy/move (understandably) introduced some complexity as well.  While reviewing the copy work, there seemed to be an opportunity to improve the code organization and controller flow.

Organization/Refactoring
---

The code improvements summary:
- Move pod management methods to `pod.go`.
- Move annotation/label management and _const_ to `annotation.go`.
- Clarify/simplify the use of labels & annotations.
- Explicit methods for dealing with _stage_ vs _final_ backup/restore.  An explict label is used to differentiate.  Implicit logic based on _includeClusterResources_ removed.
- Functional decomposition (just a few methods).

Controller Flow
---
The additional phases and conditional logic needed to support copy further blurs the reconcile paradigm followed by the migration controller.  An effort has been made to follow the conventional, declarative kubernetes paradigm for reconcile.  That is, to _ensure_ that the world is as the Spec declares that it should be.  Currently, this is only partially followed by the migration controller.  On each Task.Run(), backup & restore is ensured to exist while at the same time the Phase (and an annotation) is considered in conditional logic regarding how far the Run() should progress and to prevent phases (steps) from being repeated.  This is out of necessity.  The migration _"run"_ requires that steps be done in a particular order and some cannot be repeated.  Further, some earlier steps should not be _ensured_ once later steps have been initiated.  For example, the initial backup should not be re-created/updated after the stage pods have been created or the applications have been quiesced; the stage backup should not be re-created/updated after the stage restore has been created (started).

This PR revisits the _stage machine_ approach discussed earlier by the controller team.  It's based on the following assertions:
- The migration controller reconcile needs to do things in order and only once.
- The `Phase` can be considered part of the _declarative_ (I know this is a stretch).
- Each phase must be resumable.
- Phases run only once and in order.
- Phases (itinerary) need to be adjusted dynamically as the migration runs and either more information is available or to  _clean things up_ after a migration has failed.

The Task.Run() is a big _switch_ statement.  Each time Run() is called (1) phase is completed; the Phase is updated to the next phase; the Task.Requeue is set (as needed) and it returns.  The Task.Requeue is needed because for some phases, the reconcile is triggered by a _watch_ while others are not.  Because the _earlier_ phases are not repeated, there is no point in storing all of the backups and restores on the Task to be used in later phases.  Instead, a needed backup or restore is fetched when needed.  The net result actually is less queries since later phases will not be fetching things that are no longer needed.

This PR (and approach) includes the resolution of the following issues:
- Failed migrations leaves undesirable artifacts: stage pods, user resources with labels and annotations which causes subsequent migrations to fail or have undesirable results.
- Stage phases skipped when Plan.PersistentVolumes is empty.  No longer need to include namespaces in the stage backup as a workaround for empty Restore failing.

For me, this approach makes following and maintaining the logic in the migration controller much clear.  It provides looser coupling of phases which makes adjusting the flow though the phases easier to adjust.