### PR TITLE
Conditions fixes and new features.

### DIFF
--- a/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
@@ -49,6 +49,11 @@ func (in *BackupStorageConfig) DeepCopy() *BackupStorageConfig {
 func (in *Condition) DeepCopyInto(out *Condition) {
 	*out = *in
 	in.LastTransitionTime.DeepCopyInto(&out.LastTransitionTime)
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -2,13 +2,10 @@ package migplan
 
 import (
 	"context"
-	"fmt"
-	"reflect"
-	"strings"
-
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"reflect"
 
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
@@ -67,10 +64,10 @@ const (
 	StorageNotReadyMessage                = "The referenced `migStorageRef` does not have a `Ready` condition."
 	NsListEmptyMessage                    = "The `namespaces` list may not be empty."
 	InvalidDestinationClusterMessage      = "The `srcMigClusterRef` and `dstMigClusterRef` cannot be the same."
-	NsNotFoundOnSourceClusterMessage      = "Namespaces [%s] not found on the source cluster."
-	NsNotFoundOnDestinationClusterMessage = "Namespaces [%s] not found on the destination cluster."
-	PvInvalidActionMessage                = "PV in `persistentVolumes` [%s] has an unsupported `action`."
-	PvNoSupportedActionMessage            = "PV in `persistentVolumes` [%s] with no `SupportedActions`."
+	NsNotFoundOnSourceClusterMessage      = "Namespaces [] not found on the source cluster."
+	NsNotFoundOnDestinationClusterMessage = "Namespaces [] not found on the destination cluster."
+	PvInvalidActionMessage                = "PV in `persistentVolumes` [] has an unsupported `action`."
+	PvNoSupportedActionMessage            = "PV in `persistentVolumes` [] with no `SupportedActions`."
 	StorageEnsuredMessage                 = "The storage resources have been created."
 	RegistriesEnsuredMessage              = "The migration registry resources have been created."
 	PvsDiscoveredMessage                  = "The `persistentVolumes` list has been updated with discovered PVs."
@@ -343,13 +340,13 @@ func (r ReconcileMigPlan) validateSourceNamespaces(plan *migapi.MigPlan) error {
 		}
 	}
 	if len(notFound) > 0 {
-		message := fmt.Sprintf(NsNotFoundOnSourceClusterMessage, strings.Join(notFound, ", "))
 		plan.Status.SetCondition(migapi.Condition{
 			Type:     NsNotFoundOnSourceCluster,
 			Status:   True,
 			Reason:   NotFound,
 			Category: Critical,
-			Message:  message,
+			Message:  NsNotFoundOnSourceClusterMessage,
+			Items:    notFound,
 		})
 		return nil
 	}
@@ -390,13 +387,13 @@ func (r ReconcileMigPlan) validateDestinationNamespaces(plan *migapi.MigPlan) er
 		}
 	}
 	if len(notFound) > 0 {
-		message := fmt.Sprintf(NsNotFoundOnDestinationClusterMessage, strings.Join(notFound, ", "))
 		plan.Status.SetCondition(migapi.Condition{
 			Type:     NsNotFoundOnDestinationCluster,
 			Status:   True,
 			Reason:   NotFound,
 			Category: Critical,
-			Message:  message,
+			Message:  NsNotFoundOnDestinationClusterMessage,
+			Items:    notFound,
 		})
 		return nil
 	}
@@ -424,26 +421,22 @@ func (r ReconcileMigPlan) validatePvAction(plan *migapi.MigPlan) error {
 		}
 	}
 	if len(invalid) > 0 {
-		message := fmt.Sprintf(
-			PvInvalidActionMessage,
-			strings.Join(invalid, ", "))
 		plan.Status.SetCondition(migapi.Condition{
 			Type:     PvInvalidAction,
 			Status:   True,
 			Reason:   NotDone,
 			Category: Error,
-			Message:  message,
+			Message:  PvInvalidActionMessage,
+			Items:    invalid,
 		})
 	}
 	if len(unsupported) > 0 {
-		message := fmt.Sprintf(
-			PvNoSupportedActionMessage,
-			strings.Join(unsupported, ", "))
 		plan.Status.SetCondition(migapi.Condition{
 			Type:     PvNoSupportedAction,
 			Status:   True,
 			Category: Warn,
-			Message:  message,
+			Message:  PvNoSupportedActionMessage,
+			Items:    unsupported,
 		})
 		return nil
 	}

--- a/pkg/controller/migstorage/validation.go
+++ b/pkg/controller/migstorage/validation.go
@@ -1,11 +1,9 @@
 package migstorage
 
 import (
-	"fmt"
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
 	kapi "k8s.io/api/core/v1"
-	"strings"
 )
 
 // Notes:
@@ -47,11 +45,11 @@ const (
 const (
 	ReadyMessage                    = "The storage is ready."
 	InvalidBSLProviderMessage       = "The `backupStorageProvider` must be: (aws|gcp|azure)."
-	InvalidBSLSettingsMessage       = "The `backupStorageConfig` settings [%s] not valid."
+	InvalidBSLSettingsMessage       = "The `backupStorageConfig` settings [] not valid."
 	InvalidBSLCredsSecretRefMessage = "The `backupStorageConfig.credsSecretRef` must reference a `secret`."
 	InvalidBSLCredsSecretMessage    = "The `backupStorageConfig.credsSecretRef` secret has invalid content."
 	InvalidVSLProviderMessage       = "The `volumeSnapshotProvider` must be: (aws|gcp|azure)."
-	InvalidVSLSettingsMessage       = "The `volumeSnapshotConfig` settings [%s] not valid."
+	InvalidVSLSettingsMessage       = "The `volumeSnapshotConfig` settings [] not valid."
 	InvalidVSLCredsSecretRefMessage = "The `volumeSnapshotConfig.credsSecretRef` must reference a `secret`."
 	InvalidVSLCredsSecretMessage    = "The `volumeSnapshotConfig.credsSecretRef` secret has invalid content."
 )
@@ -125,13 +123,13 @@ func (r ReconcileMigStorage) validateAwsBSLSettings(storage *migapi.MigStorage) 
 
 	// Set condition.
 	if len(fields) > 0 {
-		message := fmt.Sprintf(InvalidBSLSettingsMessage, strings.Join(fields, ", "))
 		storage.Status.SetCondition(migapi.Condition{
 			Type:     InvalidBSLProvider,
 			Status:   True,
 			Category: Critical,
 			Reason:   InvalidSetting,
-			Message:  message,
+			Message:  InvalidBSLSettingsMessage,
+			Items:    fields,
 		})
 		return nil
 	}
@@ -153,13 +151,13 @@ func (r ReconcileMigStorage) validateAzureBSLSettings(storage *migapi.MigStorage
 
 	// Set condition.
 	if len(fields) > 0 {
-		message := fmt.Sprintf(InvalidBSLSettingsMessage, strings.Join(fields, ", "))
 		storage.Status.SetCondition(migapi.Condition{
 			Type:     InvalidBSLProvider,
 			Status:   True,
 			Category: Critical,
 			Reason:   InvalidSetting,
-			Message:  message,
+			Message:  InvalidBSLSettingsMessage,
+			Items:    fields,
 		})
 		return nil
 	}
@@ -262,13 +260,13 @@ func (r ReconcileMigStorage) validateAwsVSLSettings(storage *migapi.MigStorage) 
 
 	// Set condition.
 	if len(fields) > 0 {
-		message := fmt.Sprintf(InvalidVSLSettingsMessage, strings.Join(fields, ", "))
 		storage.Status.SetCondition(migapi.Condition{
 			Type:     InvalidVSLProvider,
 			Status:   True,
 			Reason:   InvalidSetting,
 			Category: Critical,
-			Message:  message,
+			Message:  InvalidVSLSettingsMessage,
+			Items:    fields,
 		})
 		return nil
 	}
@@ -290,13 +288,13 @@ func (r ReconcileMigStorage) validateAzureVSLSettings(storage *migapi.MigStorage
 
 	// Set condition.
 	if len(fields) > 0 {
-		message := fmt.Sprintf(InvalidVSLSettingsMessage, strings.Join(fields, ", "))
 		storage.Status.SetCondition(migapi.Condition{
 			Type:     InvalidVSLProvider,
 			Status:   True,
 			Reason:   InvalidSetting,
 			Category: Critical,
-			Message:  message,
+			Message:  InvalidVSLSettingsMessage,
+			Items:    fields,
 		})
 		return nil
 	}


### PR DESCRIPTION
Fix the `Conditions.FindCondition()` to respect _staging_.

Add support for _Durable_ conditions needed by new migration work .  A durable condition is preserved across staging.

Add better support for conditions that include a _list of items_ in the `Message`.  The `Message` may include `[]` which is a placeholder for the content of `Items`.  For example: 
```
list := []string{"A, "B"}

condition = Condition{
  Type:     "ThingsNotFound",
  Status:   True,
  Reason:   "NotFound",
  Category: Critical,
  Message:  "These things [] not found.",
  Items: list,
}
```

I anticipate this will be useful for the _StorageClass_ work in progress.