### PR TITLE
Add validation for conflicting plans.

### DIFF
--- a/pkg/apis/migration/v1alpha1/condition_test.go
+++ b/pkg/apis/migration/v1alpha1/condition_test.go
@@ -383,7 +383,6 @@ func TestConditions_HasConditionCategoryStaging(t *testing.T) {
 	g.Expect(conditions.HasConditionCategory(Critical)).To(gomega.BeFalse())
 }
 
-
 func TestConditions_AppendingItems(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 

--- a/pkg/apis/migration/v1alpha1/model.go
+++ b/pkg/apis/migration/v1alpha1/model.go
@@ -6,17 +6,19 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"strconv"
 )
 
 //
 // Convenience functions for managing the object model.
 ///
 
-// List MigPlans
+// List `open` MigPlans
 // Returns and empty list when none found.
 func ListPlans(client k8sclient.Client) ([]MigPlan, error) {
 	list := MigPlanList{}
-	err := client.List(context.TODO(), nil, &list)
+	options := k8sclient.MatchingField(ClosedIndexField, strconv.FormatBool(false))
+	err := client.List(context.TODO(), options, &list)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reference/ref.go
+++ b/pkg/reference/ref.go
@@ -12,6 +12,13 @@ func RefSet(ref *kapi.ObjectReference) bool {
 		ref.Name != ""
 }
 
+func RefEquals(refA, refB *kapi.ObjectReference) bool {
+	if refA == nil || refB == nil {
+		return false
+	}
+	return reflect.DeepEqual(refA, refB)
+}
+
 func ToKind(resource interface{}) string {
 	t := reflect.TypeOf(resource).String()
 	p := strings.SplitN(t, ".", 2)


### PR DESCRIPTION
Fixes issue #172

This is a first pass at protecting against conflicting (_overlapping_) plans.  Plans are in conflict when they are open, both have the same _source_ or _destination_ cluster and overlapping namespaces.  When detected both plans with get an _Error_ condition that will prevent them from being ready thus preventing migrations.  To resolve the conflict, one of the plans needs to be: edited, closed or deleted.

This does not address the potential issue of one plan's migration restarting restic while another plan (not in conflict) is running a backup as part of its migration.

The goal is to take an incremental step forward.  Should this prove to be insufficient or be too restrictive to the user, we can revisit.