### PR TITLE
Fix Failed condition category to support subsequent migrations.

### DIFF
--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -107,7 +107,7 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (time.Du
 			Type:     Failed,
 			Status:   False,
 			Reason:   task.Phase,
-			Category: Critical,
+			Category: Advisory,
 			Message:  FailedMessage,
 			Durable:  true,
 		})


### PR DESCRIPTION
The `Failed` condition category should be _Advisory_ so it won't block subsequent migrations.