### PR TITLE
Temporarily disable finalizers.

### DIFF
--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -74,6 +74,9 @@ func init() {
 
 // Ensure finalizer.
 func (r *MigCluster) EnsureFinalizer() bool {
+	if !FinalizerEnabled {
+		return false
+	}
 	if r.Finalizers == nil {
 		r.Finalizers = []string{}
 	}

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -83,6 +83,9 @@ func init() {
 
 // Ensure finalizer.
 func (r *MigPlan) EnsureFinalizer() bool {
+	if !FinalizerEnabled {
+		return false
+	}
 	if r.Finalizers == nil {
 		r.Finalizers = []string{}
 	}
@@ -666,9 +669,8 @@ func (r *MigPlan) HasConflict(plan *MigPlan) bool {
 
 // PV Actions.
 const (
-	PvMoveAction    = "move"
-	PvCopyAction    = "copy"
-	VeleroNamespace = "mig"
+	PvMoveAction = "move"
+	PvCopyAction = "copy"
 )
 
 // Name - The PV name.

--- a/pkg/apis/migration/v1alpha1/resource.go
+++ b/pkg/apis/migration/v1alpha1/resource.go
@@ -5,8 +5,10 @@ import (
 )
 
 const (
-	TouchAnnotation = "touch"
-	Finalizer       = "openshift.io/migration"
+	TouchAnnotation  = "touch"
+	FinalizerEnabled = false
+	Finalizer        = "openshift.io/migration"
+	VeleroNamespace  = "mig"
 )
 
 // Migration application CR.

--- a/pkg/controller/migcluster/migcluster_controller.go
+++ b/pkg/controller/migcluster/migcluster_controller.go
@@ -136,16 +136,6 @@ func (r *ReconcileMigCluster) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	// Finalizer
-	added := cluster.EnsureFinalizer()
-	if added {
-		err = r.Update(context.TODO(), cluster)
-		if err != nil {
-			log.Trace(err)
-			return reconcile.Result{Requeue: true}, nil
-		}
-	}
-
 	// Cluster deleted.
 	if cluster.DeletionTimestamp != nil {
 		retry := false
@@ -155,6 +145,15 @@ func (r *ReconcileMigCluster) Reconcile(request reconcile.Request) (reconcile.Re
 			retry = r.retryFinalizer(cluster)
 		}
 		return reconcile.Result{Requeue: retry}, nil
+	} else {
+		added := cluster.EnsureFinalizer()
+		if added {
+			err = r.Update(context.TODO(), cluster)
+			if err != nil {
+				log.Trace(err)
+				return reconcile.Result{Requeue: true}, nil
+			}
+		}
 	}
 
 	// Begin staging conditions.

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -150,16 +150,6 @@ func (r *ReconcileMigPlan) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
-	// Finalizer
-	added := plan.EnsureFinalizer()
-	if added {
-		err = r.Update(context.TODO(), plan)
-		if err != nil {
-			log.Trace(err)
-			return reconcile.Result{Requeue: true}, nil
-		}
-	}
-
 	// Plan deleted.
 	if plan.DeletionTimestamp != nil {
 		retry := false
@@ -169,6 +159,15 @@ func (r *ReconcileMigPlan) Reconcile(request reconcile.Request) (reconcile.Resul
 			retry = r.retryFinalizer(plan)
 		}
 		return reconcile.Result{Requeue: retry}, nil
+	} else {
+		added := plan.EnsureFinalizer()
+		if added {
+			err = r.Update(context.TODO(), plan)
+			if err != nil {
+				log.Trace(err)
+				return reconcile.Result{Requeue: true}, nil
+			}
+		}
 	}
 
 	// Plan closed.


### PR DESCRIPTION
Mitigate #213 and unblock folks.

There is likely an unrelated permission issue exposed by the _cleanup_ which should affect _closing_ as well.  Otherwise the plan and cluster finalizers work just fine.  The blocking problem is when users delete the entire namespace.