### PR TITLE
Add namespaces to staging resources and preserve securityContext on stage pods

### DIFF
--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
@@ -362,6 +363,11 @@ func (t *Task) deleteNamespaceLabels(client k8sclient.Client) error {
 				Name: ns,
 			},
 			&namespace)
+		// Check if namespace doesn't exist. This will happpen during prepare phase
+		// since destination cluster doesn't have the migrated namespaces yet
+		if errors.IsNotFound(err) {
+			continue
+		}
 		if err != nil {
 			log.Trace(err)
 			return err

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -28,6 +28,7 @@ import (
 var stagingResources = []string{
 	"persistentvolumes",
 	"persistentvolumeclaims",
+	"namespaces",
 	"imagestreams",
 	"imagestreamtags",
 	"secrets",

--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -109,8 +109,9 @@ func (t *Task) buildStagePod(pod *corev1.Pod) *corev1.Pod {
 			Labels: labels,
 		},
 		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{},
-			Volumes:    []corev1.Volume{},
+			Containers:      []corev1.Container{},
+			Volumes:         []corev1.Volume{},
+			SecurityContext: pod.Spec.SecurityContext,
 		},
 	}
 	// Add volumes.


### PR DESCRIPTION
This PR does 2 things.
* Add the stage label to all target namespaces so that they are explicitly included in the stage backup/restore. This allows us to mutate the annotations from within the plugin.
* Include the application pod's `securityContext` field when creating the stage pod to ensure it runs as the same uid/gid.