### PR TITLE
Restructuring generate name for the secret

### DIFF
--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -248,7 +248,7 @@ func (r *MigPlan) BuildRegistrySecret(client k8sclient.Client, storage *MigStora
 	secret := &kapi.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:       labels,
-			GenerateName: r.GetName() + "-registry-",
+			GenerateName: "registry-" + r.GetName() + "-",
 			Namespace:    VeleroNamespace,
 		},
 	}


### PR DESCRIPTION
This PR will ensure, that all generated names after the secret creation, will start with `registry-` prefix. The name, therefore, won't start with a numeric character, which suits the `[a-z]([-a-z0-9]*[a-z0-9])?` regex used for service names validation.
Closes #190 