### PR TITLE
Add pod affinity selector to stage pod definition

### DIFF
--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -112,6 +112,24 @@ func (t *Task) buildStagePod(pod *corev1.Pod) *corev1.Pod {
 			Containers:      []corev1.Container{},
 			Volumes:         []corev1.Volume{},
 			SecurityContext: pod.Spec.SecurityContext,
+			Affinity: &corev1.Affinity{
+				PodAffinity: &corev1.PodAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+						corev1.WeightedPodAffinityTerm{
+							Weight: 100,
+							PodAffinityTerm: corev1.PodAffinityTerm{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										StagePodAffinityLabel: pod.Name,
+									},
+								},
+								Namespaces:  []string{pod.Namespace},
+								TopologyKey: "kubernetes.io/hostname",
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 	// Add volumes.


### PR DESCRIPTION
Stage pods need to run on the same node as the related app pod, if possible.
Some storage types (glusterblock, for example) will cause the stage
pods to fail to start if they're on a different node as the app
pod. This PR defines a soft affinity, so it will go on the same
node if it is able to schedule it there, but if not, it will schedule
it elsewhere, limiting the failure scenario to only failing if the
desired node is unavailable *and* it's one of the affected storage
types.