### PR TITLE
Use a new label for the application pods instead of stage label

### DIFF
--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -217,7 +217,7 @@ func (t *Task) annotatePods(client k8sclient.Client) error {
 			if pod.Labels == nil {
 				pod.Labels = make(map[string]string)
 			}
-			pod.Labels[IncludedInStageBackupLabel] = t.UID()
+			pod.Labels[IncludedInStageBackupLabel] = t.StagePodSearchLabel()
 			pod.Labels[StagePodAffinityLabel] = pod.Name
 			// Update
 			err = client.Update(context.TODO(), &pod)

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -30,6 +30,9 @@ const (
 	// Resources included in the stage backup.
 	// Referenced by the Backup.LabelSelector. The value is the Task.UID().
 	IncludedInStageBackupLabel = "migration-included-stage-backup"
+	// Application pods requiring restic/stage backups.
+	// Used to create stage pods. The value is the Task.UID()
+	ApplicationPodLabel = "migration-application-pod"
 	// For pods included in the stage backup, this label contains a pod-unique
 	// value (namespace "/"+name)
 	StagePodAffinityLabel = "migration-stage-pod-affinity"
@@ -217,7 +220,7 @@ func (t *Task) annotatePods(client k8sclient.Client) error {
 			if pod.Labels == nil {
 				pod.Labels = make(map[string]string)
 			}
-			pod.Labels[IncludedInStageBackupLabel] = t.StagePodSearchLabel()
+			pod.Labels[ApplicationPodLabel] = t.UID()
 			pod.Labels[StagePodAffinityLabel] = pod.Name
 			// Update
 			err = client.Update(context.TODO(), &pod)
@@ -338,6 +341,10 @@ func (t *Task) deletePodAnnotations(client k8sclient.Client) error {
 			if pod.Labels != nil {
 				if _, found := pod.Labels[IncludedInStageBackupLabel]; found {
 					delete(pod.Labels, IncludedInStageBackupLabel)
+					needsUpdate = true
+				}
+				if _, found := pod.Labels[ApplicationPodLabel]; found {
+					delete(pod.Labels, ApplicationPodLabel)
 					needsUpdate = true
 				}
 				if _, found := pod.Labels[StagePodAffinityLabel]; found {

--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -168,7 +168,7 @@ func (t *Task) ensureStagePodsCreated() (int, error) {
 	}
 
 	labelSelector := map[string]string{
-		IncludedInStageBackupLabel: t.UID(),
+		IncludedInStageBackupLabel: t.StagePodSearchLabel(),
 	}
 	podList := corev1.PodList{}
 	options := k8sclient.MatchingLabels(labelSelector)

--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -197,7 +197,6 @@ func (t *Task) ensureStagePodsCreated() (int, error) {
 				newPod.Namespace,
 				"name",
 				newPod.Name)
-			delete(pod.Labels, IncludedInStageBackupLabel)
 			delete(pod.Annotations, ResticPvBackupAnnotation)
 			err = client.Update(context.TODO(), &pod)
 			if err != nil {

--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -168,7 +168,7 @@ func (t *Task) ensureStagePodsCreated() (int, error) {
 	}
 
 	labelSelector := map[string]string{
-		IncludedInStageBackupLabel: t.StagePodSearchLabel(),
+		ApplicationPodLabel: t.UID(),
 	}
 	podList := corev1.PodList{}
 	options := k8sclient.MatchingLabels(labelSelector)

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -1,6 +1,7 @@
 package migmigration
 
 import (
+	"fmt"
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -465,6 +466,11 @@ func (t *Task) Run() error {
 // Migration UID.
 func (t *Task) UID() string {
 	return string(t.Owner.UID)
+}
+
+// Migration Stage Pod Search Label
+func (t *Task) StagePodSearchLabel() string {
+	return fmt.Sprintf("%s-search", t.UID())
 }
 
 // Get whether the migration is stage.

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -1,7 +1,6 @@
 package migmigration
 
 import (
-	"fmt"
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -466,11 +465,6 @@ func (t *Task) Run() error {
 // Migration UID.
 func (t *Task) UID() string {
 	return string(t.Owner.UID)
-}
-
-// Migration Stage Pod Search Label
-func (t *Task) StagePodSearchLabel() string {
-	return fmt.Sprintf("%s-search", t.UID())
 }
 
 // Get whether the migration is stage.


### PR DESCRIPTION
Fixes #244 

While before we were deleting this UID label after creating the stage pod to try and keep it from being included in the backup, it causes a race condition because the resource may not be updated by the time the stage backup runs. This is far safer and the label is still properly removed since it uses the same key.

Test this PR at `docker.io/dymurray/mig-controller:stageFix`