### PR TITLE
Suspend PV discovery while migrations running or final migration succeeded.

### DIFF
--- a/pkg/apis/migration/v1alpha1/condition.go
+++ b/pkg/apis/migration/v1alpha1/condition.go
@@ -186,6 +186,23 @@ func (r *Conditions) SetCondition(condition Condition) {
 	}
 }
 
+// Stage an existing condition by type.
+func (r *Conditions) StageCondition(types ...string) {
+	if r.List == nil {
+		return
+	}
+	filter := make(map[string]bool)
+	for _, t := range types {
+		filter[t] = true
+	}
+	for i := range r.List {
+		condition := &r.List[i]
+		if _, found := filter[condition.Type]; found {
+			condition.staged = true
+		}
+	}
+}
+
 // Delete conditions by type.
 func (r *Conditions) DeleteCondition(types ...string) {
 	if r.List == nil {

--- a/pkg/apis/migration/v1alpha1/condition_test.go
+++ b/pkg/apis/migration/v1alpha1/condition_test.go
@@ -197,6 +197,32 @@ func TestConditions_SetCondition(t *testing.T) {
 		}))
 }
 
+func TestConditions_StageCondition(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// Setup
+	conditions := Conditions{
+		List: []Condition{
+			{Type: "A"},
+			{Type: "B"},
+			{Type: "C"},
+			{Type: "D"},
+		},
+	}
+
+	// Test
+	conditions.StageCondition("A", "C", "X")
+
+	// Validation
+	g.Expect(conditions.staging).To(gomega.BeFalse())
+	g.Expect(conditions.List).To(gomega.Equal([]Condition{
+		{Type: "A", staged: true},
+		{Type: "B", staged: false},
+		{Type: "C", staged: true},
+		{Type: "D", staged: false},
+	}))
+}
+
 func TestConditions_DeleteCondition(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 

--- a/pkg/controller/migplan/handler.go
+++ b/pkg/controller/migplan/handler.go
@@ -1,0 +1,29 @@
+package migplan
+
+import (
+	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
+	migref "github.com/fusor/mig-controller/pkg/reference"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func MigrationRequests(a handler.MapObject) []reconcile.Request {
+	requests := []reconcile.Request{}
+	migration, cast := a.Object.(*migapi.MigMigration)
+	if !cast {
+		return requests
+	}
+	ref := migration.Spec.MigPlanRef
+	if migref.RefSet(ref) {
+		requests = append(
+			requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: ref.Namespace,
+					Name:      ref.Name,
+				},
+			})
+	}
+
+	return requests
+}

--- a/pkg/controller/migplan/pvlist.go
+++ b/pkg/controller/migplan/pvlist.go
@@ -14,6 +14,10 @@ type Claims []migapi.PVC
 
 // Update the PVs listed on the plan.
 func (r *ReconcileMigPlan) updatePvs(plan *migapi.MigPlan) error {
+	if plan.Status.HasCondition(Suspended) {
+		plan.Status.StageCondition(PvsDiscovered)
+		return nil
+	}
 	if plan.Status.HasAnyCondition(
 		InvalidSourceClusterRef,
 		SourceClusterNotReady,

--- a/pkg/controller/migplan/registry.go
+++ b/pkg/controller/migplan/registry.go
@@ -13,6 +13,10 @@ func (r ReconcileMigPlan) ensureMigRegistries(plan *migapi.MigPlan) error {
 	var client k8sclient.Client
 	nEnsured := 0
 
+	if plan.Status.HasCriticalCondition() || plan.Status.HasAnyCondition(Suspended) {
+		plan.Status.StageCondition(RegistriesEnsured)
+		return nil
+	}
 	storage, err := plan.GetStorage(r)
 	if err != nil {
 		log.Trace(err)

--- a/pkg/controller/migplan/storage.go
+++ b/pkg/controller/migplan/storage.go
@@ -13,6 +13,10 @@ func (r ReconcileMigPlan) ensureStorage(plan *migapi.MigPlan) error {
 	var client k8sclient.Client
 	nEnsured := 0
 
+	if plan.Status.HasCriticalCondition() || plan.Status.HasAnyCondition(Suspended) {
+		plan.Status.StageCondition(StorageEnsured)
+		return nil
+	}
 	storage, err := plan.GetStorage(r)
 	if err != nil {
 		log.Trace(err)


### PR DESCRIPTION
https://github.com/fusor/mig-controller/issues/253

Introduces the concept of a plan `suspended` condition while migrations are running or the _final_ migration has completed successfully.  This is primarily intended to keep the PV list from changing while migrations are running (constantly reduced as pods are migrated) and after the _final_ migration has succeeded.

The remote watch events are propagated through the plan which causes a lot of reconciles even when the MigPlan has not changed.  To reduce load on all clusters, reconcile latency and event propagation to the migration controller the follow is also not performed while `suspended`:
- Validation:
  - velero namespace exist.
  - namespaces listed in the plan exist.
- Ensure registry resources.
- Ensure storage resources.

The plan's _suspended_ status is managed and communicated to the user using a `Suspended` condition.

The plan controller adds a watch on migrations. This is new and does introduce a _circular_ watch since the migration CR has a reference to the plan.  However, this is safe because the plan watch is filtered by a predicate:
- _Create_ events are ignored.
- _Update_ events are forwarded to the referenced plan **only** when the _Running_ condition is added/removed.
- _Create_ events are ignored.  _Delete_ events are always forwarded.

The decision to have the plan controller determine the `suspended` condition instead of the migration controller (or the user) setting the plan in/out of the suspended condition is based on  _separation-of-concerns_.  It seemed more appropriate for the plan to controller to _self_ determine when the condition exists, as well as, how the condition impacts the reconcile.