### PR TITLE
Update aws cloudprovider to work with minio/noobaa

### DIFF
--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -388,6 +388,10 @@ func (r *MigPlan) BuildRegistryDC(storage *MigStorage, name, dirName string) (*a
 
 // Update a Registry DeploymentConfig as desired for the specified cluster.
 func (r *MigPlan) UpdateRegistryDC(storage *MigStorage, deploymentconfig *appsv1.DeploymentConfig, name, dirName string) error {
+	region := storage.Spec.BackupStorageConfig.AwsRegion
+	if region == "" {
+		region = "us-east-1"
+	}
 	deploymentconfig.Spec = appsv1.DeploymentConfigSpec{
 		Replicas: 1,
 		Selector: map[string]string{
@@ -426,7 +430,11 @@ func (r *MigPlan) UpdateRegistryDC(storage *MigStorage, deploymentconfig *appsv1
 							},
 							kapi.EnvVar{
 								Name:  "REGISTRY_STORAGE_S3_REGION",
-								Value: storage.Spec.BackupStorageConfig.AwsRegion,
+								Value: region,
+							},
+							kapi.EnvVar{
+								Name:  "REGISTRY_STORAGE_S3_REGIONENDPOINT",
+								Value: storage.Spec.BackupStorageConfig.AwsS3URL,
 							},
 							kapi.EnvVar{
 								Name:  "REGISTRY_STORAGE_S3_ROOTDIRECTORY",

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -390,7 +390,7 @@ func (r *MigPlan) BuildRegistryDC(storage *MigStorage, name, dirName string) (*a
 func (r *MigPlan) UpdateRegistryDC(storage *MigStorage, deploymentconfig *appsv1.DeploymentConfig, name, dirName string) error {
 	region := storage.Spec.BackupStorageConfig.AwsRegion
 	if region == "" {
-		region = "us-east-1"
+		region = pvdr.AwsS3DefaultRegion
 	}
 	deploymentconfig.Spec = appsv1.DeploymentConfigSpec{
 		Replicas: 1,

--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -21,6 +21,7 @@ import (
 const (
 	AwsAccessKeyId     = "aws-access-key-id"
 	AwsSecretAccessKey = "aws-secret-access-key"
+	AwsS3DefaultRegion = "us-east-1"
 )
 
 // Velero cloud-secret.
@@ -131,7 +132,7 @@ func (p *AWSProvider) Validate(secret *kapi.Secret) []string {
 
 func (p *AWSProvider) GetRegion() string {
 	if p.Region == "" {
-		return "us-east-1"
+		return AwsS3DefaultRegion
 	}
 	return p.Region
 }

--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -21,6 +21,10 @@ import (
 const (
 	AwsAccessKeyId     = "aws-access-key-id"
 	AwsSecretAccessKey = "aws-secret-access-key"
+)
+
+// S3 constants
+const (
 	AwsS3DefaultRegion = "us-east-1"
 )
 

--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -62,7 +62,7 @@ func (p *AWSProvider) UpdateBSL(bsl *velero.BackupStorageLocation) {
 		},
 	}
 	bsl.Spec.Config = map[string]string{
-		"s3ForcePathStyle": strconv.FormatBool(p.S3ForcePathStyle),
+		"s3ForcePathStyle": strconv.FormatBool(p.GetForcePathStyle()),
 		"region":           p.GetRegion(),
 	}
 	if p.S3URL != "" {
@@ -130,6 +130,7 @@ func (p *AWSProvider) Validate(secret *kapi.Secret) []string {
 	return fields
 }
 
+// Returns `us-east-1` if no region is specified
 func (p *AWSProvider) GetRegion() string {
 	if p.Region == "" {
 		return AwsS3DefaultRegion
@@ -137,6 +138,8 @@ func (p *AWSProvider) GetRegion() string {
 	return p.Region
 }
 
+// Check the scheme on the configured URL. If a URL is not specified, return
+// false
 func (p *AWSProvider) GetDisableSSL() bool {
 	s3Url, err := url.Parse(p.GetURL())
 	if err != nil {
@@ -148,7 +151,13 @@ func (p *AWSProvider) GetDisableSSL() bool {
 	return false
 }
 
+// This function returns a boolean determining whether we are talking to an S3
+// endpoint that requires path style formatting. Since all S3 APIs support path
+// style, the safe approach is to default to path style if the user has
+// specified an S3 API URL. This should be updated to perform some smarter
+// interpretation of the URL.
 func (p *AWSProvider) GetForcePathStyle() bool {
+	// If the user has specified a URL, lets assume Path Style for now.
 	if p.GetURL() == "" {
 		return false
 	}


### PR DESCRIPTION
To test this you can deploy minio using `mig-agnosticd` and enter the route as the `AwsS3URL`

EDIT: Got Noobaa installed testing Noobaa out now