### PR TITLE
Delete migrations in plan finalizer.

### DIFF
--- a/pkg/controller/migcluster/migcluster_controller.go
+++ b/pkg/controller/migcluster/migcluster_controller.go
@@ -266,15 +266,17 @@ func (r *ReconcileMigCluster) clusterDeleted(cluster *migapi.MigCluster) error {
 	err = cluster.DeleteResources(r, nil)
 	if err != nil {
 		log.Trace(err)
+		return err
 	}
 	cluster.Touch()
 	cluster.DeleteFinalizer()
 	err = r.Update(context.TODO(), cluster)
 	if err != nil {
 		log.Trace(err)
+		return err
 	}
 
-	return err
+	return nil
 }
 
 // Get whether the finalizer may retry.


### PR DESCRIPTION
fixes #262

Delete migrations in the plan finalizer.

Also noticed the finalizer for plan and cluster were logging but swallowing errors. Although the finalizers are _best effort_, the swallowed error could defeat the finalizer retry algorithm. 