### PR TITLE
Quiesce pods in stage itinerary based on QuiescePods only.

### DIFF
--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -147,7 +147,11 @@ func (t *Task) Run() error {
 			if t.hasPVs() {
 				t.Phase = AnnotateResources
 			} else {
-				t.Phase = Completed
+				if t.quiesce() {
+					t.Phase = QuiesceApplications
+				} else {
+					t.Phase = Completed
+				}
 			}
 		} else {
 			t.Phase = EnsureInitialBackup
@@ -258,7 +262,11 @@ func (t *Task) Run() error {
 			return err
 		}
 		if quiesced {
-			t.Phase = EnsureStageBackup
+			if t.hasPVs() {
+				t.Phase = EnsureStageBackup
+			} else {
+				t.Phase = Completed
+			}
 		} else {
 			t.Requeue = time.Second * 3
 		}


### PR DESCRIPTION
fixes #268

Update the task _itinerary_ so that Pods are quiesced when `quiescePods: true` regardless of whether any PVs are being migrated.