### PR TITLE
Fix remote cluster sample ns typo

### DIFF
--- a/config/samples/mig-cluster-remote.yaml
+++ b/config/samples/mig-cluster-remote.yaml
@@ -12,7 +12,7 @@ spec:
 
   clusterRef:
     name: remote-cluster
-    namespace: openshift-migration-operator
+    namespace: openshift-migration
 
   serviceAccountSecretRef:
     name: sa-token-remote


### PR DESCRIPTION
As reported by Roshni Pattath, after the split NS PR was merged we have a typo in our samples.