### PR TITLE
Stage pods using the same SA.

### DIFF
--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -26,6 +26,7 @@ import (
 
 // Backup resources.
 var stagingResources = []string{
+	"serviceaccount",
 	"persistentvolumes",
 	"persistentvolumeclaims",
 	"namespaces",

--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -126,13 +126,15 @@ func (t *Task) buildStagePod(pod *corev1.Pod) *corev1.Pod {
 			Labels: labels,
 		},
 		Spec: corev1.PodSpec{
-			Containers:      []corev1.Container{},
-			Volumes:         []corev1.Volume{},
-			SecurityContext: pod.Spec.SecurityContext,
+			Containers:                   []corev1.Container{},
+			Volumes:                      []corev1.Volume{},
+			SecurityContext:              pod.Spec.SecurityContext,
+			ServiceAccountName:           pod.Spec.ServiceAccountName,
+			AutomountServiceAccountToken: pod.Spec.AutomountServiceAccountToken,
 			Affinity: &corev1.Affinity{
 				PodAffinity: &corev1.PodAffinity{
 					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-						corev1.WeightedPodAffinityTerm{
+						{
 							Weight: 100,
 							PodAffinityTerm: corev1.PodAffinityTerm{
 								LabelSelector: &metav1.LabelSelector{


### PR DESCRIPTION
Set the `ServiceAccountName` & `AutomountServiceAccountToken` on the match the application pod.
Label SAs referenced by pods to be included in the stage backup.
Include SAs in stage backup resources.