### PR TITLE
Add CronJob support to quiesce and fix bug with final stateless quiesce

### DIFF
--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -186,7 +186,11 @@ func (t *Task) Run() error {
 				if t.hasPVs() {
 					t.Phase = AnnotateResources
 				} else {
-					t.Phase = EnsureInitialBackupReplicated
+					if t.quiesce() {
+						t.Phase = QuiesceApplications
+					} else {
+						t.Phase = EnsureInitialBackupReplicated
+					}
 				}
 			}
 		} else {
@@ -266,7 +270,11 @@ func (t *Task) Run() error {
 			if t.hasPVs() {
 				t.Phase = EnsureStageBackup
 			} else {
-				t.Phase = Completed
+				if t.stage() {
+					t.Phase = Completed
+				} else {
+					t.Phase = EnsureInitialBackupReplicated
+				}
 			}
 		} else {
 			t.Requeue = time.Second * 3


### PR DESCRIPTION
1) Adds quiesce support for CronJobs: On quiesce, set Suspend to true
2) Fix task workflow bug. Stateless non-stage migrations weren't calling
   quiesce functions as appropriate.