### PR TITLE
Refactor backup resource handling to allow for CRD migration

### DIFF
--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -18,13 +18,13 @@ import (
 // Ensure the initial backup on the source cluster has been created
 // and has the proper settings.
 func (t *Task) ensureInitialBackup() (*velero.Backup, error) {
-	includeClusterResources := false
-	newBackup, err := t.buildBackup(&includeClusterResources)
+	newBackup, err := t.buildBackup(nil)
 	if err != nil {
 		log.Trace(err)
 		return nil, err
 	}
 	newBackup.Labels[InitialBackupLabel] = t.UID()
+	newBackup.Spec.ExcludedResources = excludedInitialResources
 	delete(newBackup.Annotations, QuiesceAnnotation)
 	foundBackup, err := t.getInitialBackup()
 	if err != nil {

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -36,6 +36,10 @@ var stagingResources = []string{
 	"configmaps",
 	"pods",
 }
+var excludedInitialResources = []string{
+	"persistentvolumes",
+	"persistentvolumeclaims",
+}
 
 // Perform the migration.
 func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (time.Duration, error) {


### PR DESCRIPTION
This commit doesn't fix CRD migration (Velero changes are needed
to complete this fix), but this removes the controller bug that
was preventing CRDs from being included in the backup:

1) Set includeClusterResources to nil for final backup.
   This allows related cluster resources to be backed up without
   backing *everything* up. Previously this was set to false,
   preventing any cluster resources from being included
2) explicitly exclude PV and PVC from initial backup/final restore.
   includeClusterResources=false was keeping PVs from the backup
   before, but with the change in 1), they need to be explicitly
   excluded.