### PR TITLE
Fix unknown kind on 3.7 quiesce.

### DIFF
--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -25,7 +25,7 @@ import (
 	velero "github.com/heptio/velero/pkg/apis/velero/v1"
 	ocapi "github.com/openshift/api/apps/v1"
 	imgapi "github.com/openshift/api/image/v1"
-	"k8s.io/api/apps/v1"
+	"k8s.io/api/apps/v1beta1"
 	kapi "k8s.io/api/core/v1"
 	storageapi "k8s.io/api/storage/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
@@ -243,7 +243,7 @@ func (m *MigCluster) DeleteResources(client k8sclient.Client, labels map[string]
 	options := k8sclient.MatchingLabels(labels)
 
 	// Deployment
-	dList := v1.DeploymentList{}
+	dList := v1beta1.DeploymentList{}
 	err = client.List(context.TODO(), options, &dList)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fix unknown kind on 3.7 quiesce for: Deployment,StatefulSet, ReplicaSet, DaemonSet, CronJob.  Also noticed during testing that `quiesceApplications()` was logging errors but not return them so the reconcile() did not fail and retry.

Tested on OCP 3.7 and 3.11.

fixes #293