### PR TITLE
Add top-level "migration-controller-generated" annotation

### DIFF
--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -13,11 +13,12 @@ import (
 
 // Velero Plugin Annotations
 const (
-	StageOrFinalAnnotation   = "openshift.io/migrate-copy-phase"   // (stage|final)
-	PvActionAnnotation       = "openshift.io/migrate-type"         // (move|copy)
-	PvStorageClassAnnotation = "openshift.io/target-storage-class" // storageClassName
-	PvAccessModeAnnotation   = "openshift.io/target-access-mode"   // accessMode
-	QuiesceAnnotation        = "openshift.io/migrate-quiesce-pods" // (true|false)
+	ControllerGenerated      = "openshift.io/migration-controller-generated" // (true)
+	StageOrFinalAnnotation   = "openshift.io/migrate-copy-phase"             // (stage|final)
+	PvActionAnnotation       = "openshift.io/migrate-type"                   // (move|copy)
+	PvStorageClassAnnotation = "openshift.io/target-storage-class"           // storageClassName
+	PvAccessModeAnnotation   = "openshift.io/target-access-mode"             // accessMode
+	QuiesceAnnotation        = "openshift.io/migrate-quiesce-pods"           // (true|false)
 )
 
 // Restic Annotations

--- a/pkg/controller/migmigration/migrate.go
+++ b/pkg/controller/migmigration/migrate.go
@@ -122,6 +122,7 @@ func (r *ReconcileMigMigration) migrate(migration *migapi.MigMigration) (time.Du
 // migrateAnnnotationKey
 func (r *ReconcileMigMigration) getAnnotations(migration *migapi.MigMigration) map[string]string {
 	annotations := make(map[string]string)
+	annotations[ControllerGenerated] = "true"
 	if migration.Spec.Stage {
 		annotations[StageOrFinalAnnotation] = "stage"
 	} else {


### PR DESCRIPTION
To support a future general-purpose velero plugin image, this
adds a "migration-controller-generated" annotation to backup and
restore CRs so that the plugin can conditionally exclude migration-
specific content within the plugin without having to guess based
on the presence of more specific annotations (stage, final, etc.).