### PR TITLE
Fix SEGV when credentials secret not found.

### DIFF
--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -228,7 +228,7 @@ func (r *MigPlan) UpdateRegistrySecret(client k8sclient.Client, storage *MigStor
 		return err
 	}
 	if credSecret == nil {
-		return CredSecretNotFound
+		return errors.New("Credentials secret not found.")
 	}
 	secret.Data = map[string][]byte{
 		"access_key": []byte(credSecret.Data[pvdr.AwsAccessKeyId]),

--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -33,9 +33,6 @@ const (
 	GCP   = pvdr.GCP
 )
 
-// Error
-var CredSecretNotFound = errors.New("Credentials secret not found.")
-
 // MigStorageSpec defines the desired state of MigStorage
 type MigStorageSpec struct {
 	BackupStorageProvider  string `json:"backupStorageProvider"`
@@ -161,6 +158,9 @@ func (r *MigStorage) UpdateBSLCloudSecret(client k8sclient.Client, cloudSecret *
 	if err != nil {
 		return err
 	}
+	if secret == nil {
+		return errors.New("Credentials secret not found.")
+	}
 	provider := r.GetBackupStorageProvider()
 	provider.UpdateCloudSecret(secret, cloudSecret)
 	return nil
@@ -185,6 +185,9 @@ func (r *MigStorage) UpdateVSLCloudSecret(client k8sclient.Client, cloudSecret *
 	secret, err := r.GetVolumeSnapshotCredSecret(client)
 	if err != nil {
 		return err
+	}
+	if secret == nil {
+		return errors.New("Credentials secret not found.")
 	}
 	provider := r.GetBackupStorageProvider()
 	provider.UpdateCloudSecret(secret, cloudSecret)

--- a/pkg/controller/migplan/registry.go
+++ b/pkg/controller/migplan/registry.go
@@ -22,7 +22,7 @@ func (r ReconcileMigPlan) ensureMigRegistries(plan *migapi.MigPlan) error {
 		log.Trace(err)
 		return err
 	}
-	if storage == nil {
+	if storage == nil || !storage.Status.IsReady() {
 		return nil
 	}
 	clusters, err := r.planClusters(plan)

--- a/pkg/controller/migplan/storage.go
+++ b/pkg/controller/migplan/storage.go
@@ -22,7 +22,7 @@ func (r ReconcileMigPlan) ensureStorage(plan *migapi.MigPlan) error {
 		log.Trace(err)
 		return err
 	}
-	if storage == nil {
+	if storage == nil || !storage.Status.IsReady() {
 		return nil
 	}
 	clusters, err := r.planClusters(plan)


### PR DESCRIPTION
Fix SEGV when _credentials_ secret not found.
- Check for `nil` to be safe.
- Skip ensuring storage and registry when storage not `Ready`.

This should probably be included in 1.0.