### PR TITLE
Pull s3-specific registry creation bits into provider

### DIFF
--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -2,6 +2,7 @@ package cloudprovider
 
 import (
 	velero "github.com/heptio/velero/pkg/apis/velero/v1"
+	appsv1 "github.com/openshift/api/apps/v1"
 	kapi "k8s.io/api/core/v1"
 )
 
@@ -21,6 +22,12 @@ func (p *AzureProvider) UpdateVSL(vsl *velero.VolumeSnapshotLocation) {
 }
 
 func (p *AzureProvider) UpdateCloudSecret(ecret, cloudSecret *kapi.Secret) {
+}
+
+func (p *AzureProvider) UpdateRegistrySecret(secret, registrySecret *kapi.Secret) {
+}
+
+func (p *AzureProvider) UpdateRegistryDC(deploymentconfig *appsv1.DeploymentConfig, name, dirName string) {
 }
 
 func (p *AzureProvider) Validate(secret *kapi.Secret) []string {

--- a/pkg/cloudprovider/gcp.go
+++ b/pkg/cloudprovider/gcp.go
@@ -2,6 +2,7 @@ package cloudprovider
 
 import (
 	velero "github.com/heptio/velero/pkg/apis/velero/v1"
+	appsv1 "github.com/openshift/api/apps/v1"
 	kapi "k8s.io/api/core/v1"
 )
 
@@ -18,6 +19,12 @@ func (p *GCPProvider) UpdateVSL(vsl *velero.VolumeSnapshotLocation) {
 }
 
 func (p *GCPProvider) UpdateCloudSecret(secret, cloudSecret *kapi.Secret) {
+}
+
+func (p *GCPProvider) UpdateRegistrySecret(secret, registrySecret *kapi.Secret) {
+}
+
+func (p *GCPProvider) UpdateRegistryDC(deploymentconfig *appsv1.DeploymentConfig, name, dirName string) {
 }
 
 func (p *GCPProvider) Validate(secret *kapi.Secret) []string {

--- a/pkg/cloudprovider/provider.go
+++ b/pkg/cloudprovider/provider.go
@@ -2,6 +2,7 @@ package cloudprovider
 
 import (
 	velero "github.com/heptio/velero/pkg/apis/velero/v1"
+	appsv1 "github.com/openshift/api/apps/v1"
 	kapi "k8s.io/api/core/v1"
 )
 
@@ -23,6 +24,8 @@ type Provider interface {
 	UpdateBSL(location *velero.BackupStorageLocation)
 	UpdateVSL(location *velero.VolumeSnapshotLocation)
 	UpdateCloudSecret(secret, cloudSecret *kapi.Secret)
+	UpdateRegistrySecret(secret, registrySecret *kapi.Secret)
+	UpdateRegistryDC(deploymentconfig *appsv1.DeploymentConfig, name, dirName string)
 	Validate(secret *kapi.Secret) []string
 	Test(secret *kapi.Secret) error
 }


### PR DESCRIPTION

Creates two new cloud provider methods:
- UpdateRegistrySecret
- UpdateRegistryDC

These methods pull the aws/s3-specific bits of the migration
registry creation into the aws provider implementation,
in preparation for supporting GCP and AWS cloud storage providers.