### PR TITLE
Replace PodAffinity with explicit NodeName selection for stage pods

### DIFF
--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -133,26 +133,10 @@ func (t *Task) buildStagePod(pod *corev1.Pod) *corev1.Pod {
 			SecurityContext:              pod.Spec.SecurityContext,
 			ServiceAccountName:           pod.Spec.ServiceAccountName,
 			AutomountServiceAccountToken: pod.Spec.AutomountServiceAccountToken,
-			Affinity: &corev1.Affinity{
-				PodAffinity: &corev1.PodAffinity{
-					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-						{
-							Weight: 100,
-							PodAffinityTerm: corev1.PodAffinityTerm{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										StagePodAffinityLabel: pod.Name,
-									},
-								},
-								Namespaces:  []string{pod.Namespace},
-								TopologyKey: "kubernetes.io/hostname",
-							},
-						},
-					},
-				},
-			},
 		},
 	}
+	// Set NodeName
+	newPod.Spec.NodeName = pod.Spec.NodeName
 	// Add volumes.
 	for _, volume := range pod.Spec.Volumes {
 		if _, found := resticVolumes[volume.Name]; found {


### PR DESCRIPTION
Replaces PodAffinity with explicit NodeName selection for stage pods,
although we only set the NodeName for pods with at least one RWO
volume. If all volumes are mounted RWX, then we don't constrain
node selection.

At the moment we don't handle the case where the selected NodeName
doesn't exist in the cluster. If it doesn't exist, then the pod will
disappear, which might confuse the controller into thinking it hasn't been
created yet. However, since the pod name is taken from the (currently
running) application pods, it's not clear whether this is actually possible,
except as a race condition where a migration is running while a node name
change is being processed, or if it's possible for a running pod to
*not* be updated of a previous NodeName change.