### PR TITLE
Check for Dest cluster conditions, nil clusters returned

### DIFF
--- a/pkg/controller/migplan/pvlist.go
+++ b/pkg/controller/migplan/pvlist.go
@@ -28,6 +28,8 @@ func (r *ReconcileMigPlan) updatePvs(plan *migapi.MigPlan) error {
 	if plan.Status.HasAnyCondition(
 		InvalidSourceClusterRef,
 		SourceClusterNotReady,
+		InvalidDestinationClusterRef,
+		DestinationClusterNotReady,
 		NsListEmpty,
 		NsNotFoundOnSourceCluster) {
 		return nil
@@ -38,6 +40,9 @@ func (r *ReconcileMigPlan) updatePvs(plan *migapi.MigPlan) error {
 	if err != nil {
 		log.Trace(err)
 		return err
+	}
+	if srcMigCluster == nil || !srcMigCluster.Status.IsReady() {
+		return nil
 	}
 
 	client, err := srcMigCluster.GetClient(r)
@@ -51,6 +56,9 @@ func (r *ReconcileMigPlan) updatePvs(plan *migapi.MigPlan) error {
 	if err != nil {
 		log.Trace(err)
 		return err
+	}
+	if destMigCluster == nil || !destMigCluster.Status.IsReady() {
+		return nil
 	}
 
 	srcStorageClasses := srcMigCluster.Spec.StorageClasses


### PR DESCRIPTION
For pvlist.go, check for dest cluster conditions in addition to
src cluster conditions. Also, check for nil cluster return
for both src and dest.