### PR TITLE
Add support for namespace change

### DIFF
--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -583,7 +583,7 @@ func (r *MigPlan) GetDestinationNamespaces() []string {
 	includedNamespaces := []string{}
 	for _, namespace := range r.Spec.Namespaces {
 		namespaces := strings.Split(namespace, ":")
-		if len(namespaces) > 0 {
+		if len(namespaces) > 1 {
 			includedNamespaces = append(includedNamespaces, namespaces[1])
 		} else {
 			includedNamespaces = append(includedNamespaces, namespaces[0])

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -578,6 +578,21 @@ func (r *MigPlan) GetSourceNamespaces() []string {
 	return includedNamespaces
 }
 
+// GetDestinationNamespaces get destination namespaces without mapping
+func (r *MigPlan) GetDestinationNamespaces() []string {
+	includedNamespaces := []string{}
+	for _, namespace := range r.Spec.Namespaces {
+		namespaces := strings.Split(namespace, ":")
+		if len(namespaces) > 0 {
+			includedNamespaces = append(includedNamespaces, namespaces[1])
+		} else {
+			includedNamespaces = append(includedNamespaces, namespaces[0])
+		}
+	}
+
+	return includedNamespaces
+}
+
 // Get whether the plan conflicts with another.
 // Plans conflict when:
 //   - Have any of the clusters in common.

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 
 	migref "github.com/fusor/mig-controller/pkg/reference"
 	velero "github.com/heptio/velero/pkg/apis/velero/v1"
@@ -564,6 +565,17 @@ func (r *MigPlan) GetCloudSecret(client k8sclient.Client) (*kapi.Secret, error) 
 			Namespace: VeleroNamespace,
 			Name:      VeleroCloudSecret,
 		})
+}
+
+// GetSourceNamespaces get source namespaces without mapping
+func (r *MigPlan) GetSourceNamespaces() []string {
+	includedNamespaces := []string{}
+	for _, namespace := range r.Spec.Namespaces {
+		namespace = strings.Split(namespace, ":")[0]
+		includedNamespaces = append(includedNamespaces, namespace)
+	}
+
+	return includedNamespaces
 }
 
 // Get whether the plan conflicts with another.

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -160,7 +160,7 @@ func (t *Task) annotatePVCs(client k8sclient.Client, pod corev1.Pod) ([]string, 
 
 // Add label to namespaces
 func (t *Task) labelNamespaces(client k8sclient.Client) error {
-	for _, ns := range t.srcNamespaces() {
+	for _, ns := range t.sourceNamespaces() {
 		namespace := corev1.Namespace{}
 		err := client.Get(
 			context.TODO(),
@@ -196,7 +196,7 @@ func (t *Task) labelNamespaces(client k8sclient.Client) error {
 // Returns a set of referenced service accounts.
 func (t *Task) annotatePods(client k8sclient.Client) (ServiceAccounts, error) {
 	serviceAccounts := ServiceAccounts{}
-	for _, ns := range t.srcNamespaces() {
+	for _, ns := range t.sourceNamespaces() {
 		list := corev1.PodList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(context.TODO(), options, &list)
@@ -309,7 +309,7 @@ func (t *Task) annotatePVs(client k8sclient.Client) error {
 
 // Add label to service accounts.
 func (t *Task) labelServiceAccounts(client k8sclient.Client, serviceAccounts ServiceAccounts) error {
-	for _, ns := range t.srcNamespaces() {
+	for _, ns := range t.sourceNamespaces() {
 		names, found := serviceAccounts[ns]
 		if !found {
 			continue

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -348,14 +348,14 @@ func (t *Task) labelServiceAccounts(client k8sclient.Client, serviceAccounts Ser
 
 // Delete temporary annotations and labels added.
 func (t *Task) deleteAnnotations() error {
-	clients, err := t.getBothClients()
+	clients, namespaceList, err := t.getBothClientsWithNamespaces()
 	if err != nil {
 		log.Trace(err)
 		return err
 	}
 
-	for _, client := range clients {
-		err = t.deletePVCAnnotations(client)
+	for i, client := range clients {
+		err = t.deletePVCAnnotations(client, namespaceList[i])
 		if err != nil {
 			log.Trace(err)
 			return err
@@ -365,12 +365,12 @@ func (t *Task) deleteAnnotations() error {
 			log.Trace(err)
 			return err
 		}
-		err = t.deletePodAnnotations(client)
+		err = t.deletePodAnnotations(client, namespaceList[i])
 		if err != nil {
 			log.Trace(err)
 			return err
 		}
-		err = t.deleteNamespaceLabels(client)
+		err = t.deleteNamespaceLabels(client, namespaceList[i])
 		if err != nil {
 			log.Trace(err)
 			return err
@@ -386,8 +386,8 @@ func (t *Task) deleteAnnotations() error {
 }
 
 // Delete Pod stage annotations and labels.
-func (t *Task) deletePodAnnotations(client k8sclient.Client) error {
-	for _, ns := range t.srcNamespaces() {
+func (t *Task) deletePodAnnotations(client k8sclient.Client, namespaceList []string) error {
+	for _, ns := range namespaceList {
 		options := k8sclient.InNamespace(ns)
 		podList := corev1.PodList{}
 		err := client.List(context.TODO(), options, &podList)
@@ -437,8 +437,8 @@ func (t *Task) deletePodAnnotations(client k8sclient.Client) error {
 }
 
 // Delete stage label from namespaces
-func (t *Task) deleteNamespaceLabels(client k8sclient.Client) error {
-	for _, ns := range t.srcNamespaces() {
+func (t *Task) deleteNamespaceLabels(client k8sclient.Client, namespaceList []string) error {
+	for _, ns := range namespaceList {
 		namespace := corev1.Namespace{}
 		err := client.Get(
 			context.TODO(),
@@ -466,8 +466,8 @@ func (t *Task) deleteNamespaceLabels(client k8sclient.Client) error {
 }
 
 // Delete PVC stage annotations and labels.
-func (t *Task) deletePVCAnnotations(client k8sclient.Client) error {
-	for _, ns := range t.srcNamespaces() {
+func (t *Task) deletePVCAnnotations(client k8sclient.Client, namespaceList []string) error {
+	for _, ns := range namespaceList {
 		options := k8sclient.InNamespace(ns)
 		pvcList := corev1.PersistentVolumeClaimList{}
 		err := client.List(context.TODO(), options, &pvcList)

--- a/pkg/controller/migmigration/annotation.go
+++ b/pkg/controller/migmigration/annotation.go
@@ -160,7 +160,7 @@ func (t *Task) annotatePVCs(client k8sclient.Client, pod corev1.Pod) ([]string, 
 
 // Add label to namespaces
 func (t *Task) labelNamespaces(client k8sclient.Client) error {
-	for _, ns := range t.namespaces() {
+	for _, ns := range t.srcNamespaces() {
 		namespace := corev1.Namespace{}
 		err := client.Get(
 			context.TODO(),
@@ -196,7 +196,7 @@ func (t *Task) labelNamespaces(client k8sclient.Client) error {
 // Returns a set of referenced service accounts.
 func (t *Task) annotatePods(client k8sclient.Client) (ServiceAccounts, error) {
 	serviceAccounts := ServiceAccounts{}
-	for _, ns := range t.namespaces() {
+	for _, ns := range t.srcNamespaces() {
 		list := corev1.PodList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(context.TODO(), options, &list)
@@ -309,7 +309,7 @@ func (t *Task) annotatePVs(client k8sclient.Client) error {
 
 // Add label to service accounts.
 func (t *Task) labelServiceAccounts(client k8sclient.Client, serviceAccounts ServiceAccounts) error {
-	for _, ns := range t.namespaces() {
+	for _, ns := range t.srcNamespaces() {
 		names, found := serviceAccounts[ns]
 		if !found {
 			continue
@@ -387,7 +387,7 @@ func (t *Task) deleteAnnotations() error {
 
 // Delete Pod stage annotations and labels.
 func (t *Task) deletePodAnnotations(client k8sclient.Client) error {
-	for _, ns := range t.namespaces() {
+	for _, ns := range t.srcNamespaces() {
 		options := k8sclient.InNamespace(ns)
 		podList := corev1.PodList{}
 		err := client.List(context.TODO(), options, &podList)
@@ -438,7 +438,7 @@ func (t *Task) deletePodAnnotations(client k8sclient.Client) error {
 
 // Delete stage label from namespaces
 func (t *Task) deleteNamespaceLabels(client k8sclient.Client) error {
-	for _, ns := range t.namespaces() {
+	for _, ns := range t.srcNamespaces() {
 		namespace := corev1.Namespace{}
 		err := client.Get(
 			context.TODO(),
@@ -467,7 +467,7 @@ func (t *Task) deleteNamespaceLabels(client k8sclient.Client) error {
 
 // Delete PVC stage annotations and labels.
 func (t *Task) deletePVCAnnotations(client k8sclient.Client) error {
-	for _, ns := range t.namespaces() {
+	for _, ns := range t.srcNamespaces() {
 		options := k8sclient.InNamespace(ns)
 		pvcList := corev1.PersistentVolumeClaimList{}
 		err := client.List(context.TODO(), options, &pvcList)

--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -3,6 +3,9 @@ package migmigration
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"time"
+
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	velero "github.com/heptio/velero/pkg/apis/velero/v1"
 	"github.com/pkg/errors"
@@ -10,9 +13,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 // Ensure the initial backup on the source cluster has been created
@@ -262,11 +263,12 @@ func (t *Task) updateBackup(backup *velero.Backup) error {
 		log.Trace(err)
 		return err
 	}
+
 	backup.Spec = velero.BackupSpec{
 		StorageLocation:         backupLocation.Name,
 		VolumeSnapshotLocations: []string{snapshotLocation.Name},
 		TTL:                     metav1.Duration{Duration: 720 * time.Hour},
-		IncludedNamespaces:      t.namespaces(),
+		IncludedNamespaces:      t.srcNamespaces(),
 		ExcludedNamespaces:      []string{},
 		IncludedResources:       t.BackupResources,
 		ExcludedResources:       []string{},

--- a/pkg/controller/migmigration/backup.go
+++ b/pkg/controller/migmigration/backup.go
@@ -268,7 +268,7 @@ func (t *Task) updateBackup(backup *velero.Backup) error {
 		StorageLocation:         backupLocation.Name,
 		VolumeSnapshotLocations: []string{snapshotLocation.Name},
 		TTL:                     metav1.Duration{Duration: 720 * time.Hour},
-		IncludedNamespaces:      t.srcNamespaces(),
+		IncludedNamespaces:      t.sourceNamespaces(),
 		ExcludedNamespaces:      []string{},
 		IncludedResources:       t.BackupResources,
 		ExcludedResources:       []string{},

--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -2,6 +2,9 @@ package migmigration
 
 import (
 	"context"
+	"strconv"
+	"strings"
+
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/fusor/mig-controller/pkg/pods"
 	corev1 "k8s.io/api/core/v1"
@@ -12,8 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/exec"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
-	"strings"
 )
 
 // Delete the running restic pods.
@@ -256,15 +257,15 @@ func (t *Task) ensureStagePodsStarted() (bool, error) {
 
 // Ensure the stage pods have been deleted.
 func (t *Task) ensureStagePodsDeleted() error {
-	clients, err := t.getBothClients()
+	clients, namespaceList, err := t.getBothClientsWithNamespaces()
 	if err != nil {
 		log.Trace(err)
 		return err
 	}
 	cLabel, _ := t.Owner.GetCorrelationLabel()
-	for _, client := range clients {
+	for i, client := range clients {
 		podList := corev1.PodList{}
-		for _, ns := range t.srcNamespaces() {
+		for _, ns := range namespaceList[i] {
 			options := k8sclient.InNamespace(ns)
 			err := client.List(context.TODO(), options, &podList)
 			if err != nil {

--- a/pkg/controller/migmigration/pod.go
+++ b/pkg/controller/migmigration/pod.go
@@ -264,7 +264,7 @@ func (t *Task) ensureStagePodsDeleted() error {
 	cLabel, _ := t.Owner.GetCorrelationLabel()
 	for _, client := range clients {
 		podList := corev1.PodList{}
-		for _, ns := range t.namespaces() {
+		for _, ns := range t.srcNamespaces() {
 			options := k8sclient.InNamespace(ns)
 			err := client.List(context.TODO(), options, &podList)
 			if err != nil {

--- a/pkg/controller/migmigration/quiesce.go
+++ b/pkg/controller/migmigration/quiesce.go
@@ -60,7 +60,7 @@ func (t *Task) quiesceApplications() error {
 
 // Scales down DeploymentConfig on source cluster
 func (t *Task) scaleDownDeploymentConfigs(client k8sclient.Client) error {
-	for _, ns := range t.PlanResources.MigPlan.Spec.Namespaces {
+	for _, ns := range t.srcNamespaces() {
 		list := appsv1.DeploymentConfigList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
@@ -90,7 +90,7 @@ func (t *Task) scaleDownDeploymentConfigs(client k8sclient.Client) error {
 // Scales down all Deployments
 func (t *Task) scaleDownDeployments(client k8sclient.Client) error {
 	zero := int32(0)
-	for _, ns := range t.PlanResources.MigPlan.Spec.Namespaces {
+	for _, ns := range t.srcNamespaces() {
 		list := v1beta1.DeploymentList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
@@ -120,7 +120,7 @@ func (t *Task) scaleDownDeployments(client k8sclient.Client) error {
 // Scales down all StatefulSets.
 func (t *Task) scaleDownStatefulSets(client k8sclient.Client) error {
 	zero := int32(0)
-	for _, ns := range t.PlanResources.MigPlan.Spec.Namespaces {
+	for _, ns := range t.srcNamespaces() {
 		list := v1beta1.StatefulSetList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
@@ -149,7 +149,7 @@ func (t *Task) scaleDownStatefulSets(client k8sclient.Client) error {
 // Scales down all ReplicaSets.
 func (t *Task) scaleDownReplicaSets(client k8sclient.Client) error {
 	zero := int32(0)
-	for _, ns := range t.PlanResources.MigPlan.Spec.Namespaces {
+	for _, ns := range t.srcNamespaces() {
 		list := extv1b1.ReplicaSetList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
@@ -183,7 +183,7 @@ const (
 
 // Scales down all DaemonSets.
 func (t *Task) scaleDownDaemonSets(client k8sclient.Client) error {
-	for _, ns := range t.PlanResources.MigPlan.Spec.Namespaces {
+	for _, ns := range t.srcNamespaces() {
 		list := extv1b1.DaemonSetList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
@@ -216,7 +216,7 @@ func (t *Task) scaleDownDaemonSets(client k8sclient.Client) error {
 // not supported in newer versions such as OCP 3.11.
 func (t *Task) suspendCronJobs(client k8sclient.Client) error {
 	fields := []string{"spec", "suspend"}
-	for _, ns := range t.PlanResources.MigPlan.Spec.Namespaces {
+	for _, ns := range t.srcNamespaces() {
 		options := k8sclient.InNamespace(ns)
 		list := unstructured.UnstructuredList{}
 		list.SetGroupVersionKind(schema.GroupVersionKind{
@@ -252,7 +252,7 @@ func (t *Task) suspendCronJobs(client k8sclient.Client) error {
 // Scales down all Jobs
 func (t *Task) scaleDownJobs(client k8sclient.Client) error {
 	zero := int32(0)
-	for _, ns := range t.PlanResources.MigPlan.Spec.Namespaces {
+	for _, ns := range t.srcNamespaces() {
 		list := batchv1.JobList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
@@ -299,7 +299,7 @@ func (t *Task) ensureQuiescedPodsTerminated() (bool, error) {
 		log.Trace(err)
 		return false, err
 	}
-	for _, ns := range t.PlanResources.MigPlan.Spec.Namespaces {
+	for _, ns := range t.srcNamespaces() {
 		list := v1.PodList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(

--- a/pkg/controller/migmigration/quiesce.go
+++ b/pkg/controller/migmigration/quiesce.go
@@ -60,7 +60,7 @@ func (t *Task) quiesceApplications() error {
 
 // Scales down DeploymentConfig on source cluster
 func (t *Task) scaleDownDeploymentConfigs(client k8sclient.Client) error {
-	for _, ns := range t.srcNamespaces() {
+	for _, ns := range t.sourceNamespaces() {
 		list := appsv1.DeploymentConfigList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
@@ -90,7 +90,7 @@ func (t *Task) scaleDownDeploymentConfigs(client k8sclient.Client) error {
 // Scales down all Deployments
 func (t *Task) scaleDownDeployments(client k8sclient.Client) error {
 	zero := int32(0)
-	for _, ns := range t.srcNamespaces() {
+	for _, ns := range t.sourceNamespaces() {
 		list := v1beta1.DeploymentList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
@@ -120,7 +120,7 @@ func (t *Task) scaleDownDeployments(client k8sclient.Client) error {
 // Scales down all StatefulSets.
 func (t *Task) scaleDownStatefulSets(client k8sclient.Client) error {
 	zero := int32(0)
-	for _, ns := range t.srcNamespaces() {
+	for _, ns := range t.sourceNamespaces() {
 		list := v1beta1.StatefulSetList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
@@ -149,7 +149,7 @@ func (t *Task) scaleDownStatefulSets(client k8sclient.Client) error {
 // Scales down all ReplicaSets.
 func (t *Task) scaleDownReplicaSets(client k8sclient.Client) error {
 	zero := int32(0)
-	for _, ns := range t.srcNamespaces() {
+	for _, ns := range t.sourceNamespaces() {
 		list := extv1b1.ReplicaSetList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
@@ -183,7 +183,7 @@ const (
 
 // Scales down all DaemonSets.
 func (t *Task) scaleDownDaemonSets(client k8sclient.Client) error {
-	for _, ns := range t.srcNamespaces() {
+	for _, ns := range t.sourceNamespaces() {
 		list := extv1b1.DaemonSetList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
@@ -216,7 +216,7 @@ func (t *Task) scaleDownDaemonSets(client k8sclient.Client) error {
 // not supported in newer versions such as OCP 3.11.
 func (t *Task) suspendCronJobs(client k8sclient.Client) error {
 	fields := []string{"spec", "suspend"}
-	for _, ns := range t.srcNamespaces() {
+	for _, ns := range t.sourceNamespaces() {
 		options := k8sclient.InNamespace(ns)
 		list := unstructured.UnstructuredList{}
 		list.SetGroupVersionKind(schema.GroupVersionKind{
@@ -252,7 +252,7 @@ func (t *Task) suspendCronJobs(client k8sclient.Client) error {
 // Scales down all Jobs
 func (t *Task) scaleDownJobs(client k8sclient.Client) error {
 	zero := int32(0)
-	for _, ns := range t.srcNamespaces() {
+	for _, ns := range t.sourceNamespaces() {
 		list := batchv1.JobList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(
@@ -299,7 +299,7 @@ func (t *Task) ensureQuiescedPodsTerminated() (bool, error) {
 		log.Trace(err)
 		return false, err
 	}
-	for _, ns := range t.srcNamespaces() {
+	for _, ns := range t.sourceNamespaces() {
 		list := v1.PodList{}
 		options := k8sclient.InNamespace(ns)
 		err := client.List(

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -573,9 +573,14 @@ func (t *Task) stage() bool {
 	return t.Owner.Spec.Stage
 }
 
-// Get the migration namespaces.
+// Get the migration namespaces with mapping.
 func (t *Task) namespaces() []string {
 	return t.PlanResources.MigPlan.Spec.Namespaces
+}
+
+// Get the migration source namespaces without mapping.
+func (t *Task) srcNamespaces() []string {
+	return t.PlanResources.MigPlan.GetSourceNamespaces()
 }
 
 // Get whether to quiesce pods.

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -579,12 +579,12 @@ func (t *Task) namespaces() []string {
 }
 
 // Get the migration source namespaces without mapping.
-func (t *Task) srcNamespaces() []string {
+func (t *Task) sourceNamespaces() []string {
 	return t.PlanResources.MigPlan.GetSourceNamespaces()
 }
 
 // Get the migration source namespaces without mapping.
-func (t *Task) destNamespaces() []string {
+func (t *Task) destinationNamespaces() []string {
 	return t.PlanResources.MigPlan.GetDestinationNamespaces()
 }
 
@@ -652,7 +652,7 @@ func (t *Task) getBothClientsWithNamespaces() ([]k8sclient.Client, [][]string, e
 		log.Trace(err)
 		return nil, nil, err
 	}
-	namespaceList := [][]string{t.srcNamespaces(), t.destNamespaces()}
+	namespaceList := [][]string{t.sourceNamespaces(), t.destinationNamespaces()}
 
 	return clientList, namespaceList, nil
 }

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -631,25 +631,28 @@ func (t *Task) getBothClusters() []*migapi.MigCluster {
 }
 
 // Get both source and destination clients.
+func (t *Task) getBothClients() ([]k8sclient.Client, error) {
+	list := []k8sclient.Client{}
+	for _, cluster := range t.getBothClusters() {
+		client, err := cluster.GetClient(t.Client)
+		if err != nil {
+			log.Trace(err)
+			return nil, err
+		}
+		list = append(list, client)
+	}
+
+	return list, nil
+}
+
+// Get both source and destination clients with associated namespaces.
 func (t *Task) getBothClientsWithNamespaces() ([]k8sclient.Client, [][]string, error) {
-	clientList := []k8sclient.Client{}
-	namespaceList := [][]string{}
-
-	sourceClient, err := t.getSourceClient()
+	clientList, err := t.getBothClients()
 	if err != nil {
 		log.Trace(err)
 		return nil, nil, err
 	}
-	clientList = append(clientList, sourceClient)
-	namespaceList = append(namespaceList, t.srcNamespaces())
-
-	destClient, err := t.getSourceClient()
-	if err != nil {
-		log.Trace(err)
-		return nil, nil, err
-	}
-	clientList = append(clientList, destClient)
-	namespaceList = append(namespaceList, t.destNamespaces())
+	namespaceList := [][]string{t.srcNamespaces(), t.destNamespaces()}
 
 	return clientList, namespaceList, nil
 }

--- a/pkg/controller/migplan/pvlist.go
+++ b/pkg/controller/migplan/pvlist.go
@@ -2,12 +2,13 @@ package migplan
 
 import (
 	"context"
+	"strings"
+
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
 type PvMap map[types.NamespacedName]core.PersistentVolume
@@ -72,7 +73,7 @@ func (r *ReconcileMigPlan) updatePvs(plan *migapi.MigPlan) error {
 		log.Trace(err)
 		return err
 	}
-	namespaces := plan.Spec.Namespaces
+	namespaces := plan.GetSourceNamespaces()
 	claims, err := r.getClaims(client, namespaces)
 	if err != nil {
 		log.Trace(err)

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -2,12 +2,14 @@ package migplan
 
 import (
 	"context"
+	"reflect"
+	"strings"
+
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
 )
 
 // Types
@@ -361,6 +363,8 @@ func (r ReconcileMigPlan) validateSourceNamespaces(plan *migapi.MigPlan) error {
 	ns := kapi.Namespace{}
 	notFound := make([]string, 0)
 	for _, name := range namespaces {
+		namespaceMapping := strings.Split(name, ":")
+		name = namespaceMapping[0]
 		key := types.NamespacedName{Name: name}
 		err := client.Get(context.TODO(), key, &ns)
 		if err == nil {


### PR DESCRIPTION
This PR adds ability to pass namespace mapping for velero restore using `Namespaces` field of migplan, example: 
```
 namespaces:
    - foo1:bar1
    - bar2
```

