### PR TITLE
Add keepAnnotations flag to MigMigration

### DIFF
--- a/config/crds/migration_v1alpha1_migmigration.yaml
+++ b/config/crds/migration_v1alpha1_migmigration.yaml
@@ -28,6 +28,8 @@ spec:
           type: object
         spec:
           properties:
+            keepAnnotations:
+              type: boolean
             migPlanRef:
               type: object
             quiescePods:

--- a/config/samples/mig-migration.yaml
+++ b/config/samples/mig-migration.yaml
@@ -10,6 +10,8 @@ spec:
   stage: false
   # [!] Set 'quiescePods: true' to scale down Pods on the source cluster after the 'Backup' stage of a migration has finished
   quiescePods: false
+  # [!] Set 'keepAnnotations: true' to retain labels and annotations applied by the migration
+  keepAnnotations: false
 
   migPlanRef:
     name: migplan-sample

--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -29,9 +29,10 @@ const (
 
 // MigMigrationSpec defines the desired state of MigMigration
 type MigMigrationSpec struct {
-	MigPlanRef  *kapi.ObjectReference `json:"migPlanRef,omitempty"`
-	Stage       bool                  `json:"stage"`
-	QuiescePods bool                  `json:"quiescePods,omitempty"`
+	MigPlanRef      *kapi.ObjectReference `json:"migPlanRef,omitempty"`
+	Stage           bool                  `json:"stage"`
+	QuiescePods     bool                  `json:"quiescePods,omitempty"`
+	KeepAnnotations bool                  `json:"keepAnnotations,omitempty"`
 }
 
 // MigMigrationStatus defines the observed state of MigMigration

--- a/pkg/controller/migmigration/task.go
+++ b/pkg/controller/migmigration/task.go
@@ -388,10 +388,12 @@ func (t *Task) Run() error {
 		}
 		t.next()
 	case EnsureAnnotationsDeleted:
-		err := t.deleteAnnotations()
-		if err != nil {
-			log.Trace(err)
-			return err
+		if !t.keepAnnotations() {
+			err := t.deleteAnnotations()
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
 		}
 		t.next()
 	case EnsureInitialBackupReplicated:
@@ -458,10 +460,12 @@ func (t *Task) Run() error {
 			log.Trace(err)
 			return err
 		}
-		err = t.deleteAnnotations()
-		if err != nil {
-			log.Trace(err)
-			return err
+		if !t.keepAnnotations() {
+			err = t.deleteAnnotations()
+			if err != nil {
+				log.Trace(err)
+				return err
+			}
 		}
 		t.Requeue = NoReQ
 		t.next()
@@ -560,6 +564,11 @@ func (t *Task) namespaces() []string {
 // Get whether to quiesce pods.
 func (t *Task) quiesce() bool {
 	return t.Owner.Spec.QuiescePods
+}
+
+// Get whether to retain annotations
+func (t *Task) keepAnnotations() bool {
+	return t.Owner.Spec.KeepAnnotations
 }
 
 // Get a client for the source cluster.


### PR DESCRIPTION
Adds a flag to allow labels and annotations applied during the migration
to stick around after the migration is completed for debugging purposes.

Fixes #312