### PR TITLE
Add cloud provider watch; routinely run provider tests.

### DIFF
--- a/pkg/apis/migration/v1alpha1/model.go
+++ b/pkg/apis/migration/v1alpha1/model.go
@@ -113,6 +113,18 @@ func GetStorage(client k8sclient.Client, ref *kapi.ObjectReference) (*MigStorage
 	return &object, err
 }
 
+// List MigStorage
+// Returns and empty list when none found.
+func ListStorage(client k8sclient.Client) ([]MigStorage, error) {
+	list := MigStorageList{}
+	err := client.List(context.TODO(), nil, &list)
+	if err != nil {
+		return nil, err
+	}
+
+	return list.Items, err
+}
+
 // List MigMigrations
 // Returns and empty list when none found.
 func ListMigrations(client k8sclient.Client) ([]MigMigration, error) {

--- a/pkg/controller/migstorage/migstorage_controller.go
+++ b/pkg/controller/migstorage/migstorage_controller.go
@@ -19,6 +19,7 @@ package migstorage
 import (
 	"context"
 	"github.com/fusor/mig-controller/pkg/logging"
+	"time"
 
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	migref "github.com/fusor/mig-controller/pkg/reference"
@@ -79,6 +80,17 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 					return migref.GetRequests(a, migapi.MigStorage{})
 				}),
 		})
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+
+	// Watch for changes to cloud providers.
+	err = c.Watch(
+		&ProviderSource{
+			Client:   mgr.GetClient(),
+			Interval: time.Second * 30},
+		&handler.EnqueueRequestForObject{})
 	if err != nil {
 		log.Trace(err)
 		return err

--- a/pkg/controller/migstorage/provider.go
+++ b/pkg/controller/migstorage/provider.go
@@ -1,0 +1,100 @@
+package migstorage
+
+import (
+	"github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	event2 "sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"time"
+)
+
+// A cloud provider `watch` source used to routinely run provider tests.
+//   Client - A controller-runtime client.
+//   Interval - The connection test interval.
+type ProviderSource struct {
+	Client     client.Client
+	Interval   time.Duration
+	handler    handler.EventHandler
+	queue      workqueue.RateLimitingInterface
+	predicates []predicate.Predicate
+}
+
+// Start the source.
+func (p *ProviderSource) Start(
+	handler handler.EventHandler,
+	queue workqueue.RateLimitingInterface,
+	predicates ...predicate.Predicate) error {
+
+	p.handler = handler
+	p.queue = queue
+	p.predicates = predicates
+	go p.run()
+
+	return nil
+}
+
+// Run the scheduled connection tests.
+func (p *ProviderSource) run() {
+	for {
+		time.Sleep(p.Interval)
+		list, err := v1alpha1.ListStorage(p.Client)
+		if err != nil {
+			log.Trace(err)
+			return
+		}
+		for _, storage := range list {
+			if storage.Status.HasAnyCondition(
+				InvalidBSProvider,
+				InvalidBSCredsSecretRef,
+				InvalidBSFields,
+				InvalidVSProvider,
+				InvalidVSCredsSecretRef,
+				InvalidVSFields) {
+				continue
+			}
+			// Storage Provider
+			secret, err := storage.GetBackupStorageCredSecret(p.Client)
+			if err != nil {
+				log.Trace(err)
+				return
+			}
+			provider := storage.GetBackupStorageProvider()
+			err = provider.Test(secret)
+			if (!storage.Status.HasCondition(BSProviderTestFailed) && err != nil) ||
+				(storage.Status.HasCondition(BSProviderTestFailed) && err == nil) {
+				p.enqueue(storage)
+				continue
+			}
+			// Snapshot Provider
+			secret, err = storage.GetVolumeSnapshotCredSecret(p.Client)
+			if err != nil {
+				log.Trace(err)
+				return
+			}
+			provider = storage.GetVolumeSnapshotProvider()
+			err = provider.Test(secret)
+			if (!storage.Status.HasCondition(VSProviderTestFailed) && err != nil) ||
+				(storage.Status.HasCondition(VSProviderTestFailed) && err == nil) {
+				p.enqueue(storage)
+				continue
+			}
+		}
+	}
+}
+
+// Enqueue a reconcile request.
+func (p *ProviderSource) enqueue(storage v1alpha1.MigStorage) {
+	event := event2.GenericEvent{
+		Meta:   &storage.ObjectMeta,
+		Object: &storage,
+	}
+	for _, predicate := range p.predicates {
+		if !predicate.Generic(event) {
+			return
+		}
+	}
+
+	p.handler.Generic(event, p.queue)
+}


### PR DESCRIPTION
Add custom _watch_ Source used to monitor the health of cloud provider.  Routinely runs provider tests and triggers reconcile when that status changes.

Interval= 30 seconds.  Seem right?

fixes #292