### PR TITLE
 Add a S3URL/PublicURL scheme check to AWSProvider.Validate

### DIFF
--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -186,6 +186,18 @@ func (p *AWSProvider) Validate(secret *kapi.Secret) []string {
 			p.SignatureVersion == "4") {
 			fields = append(fields, "SignatureVersion")
 		}
+		if p.S3URL != "" {
+			u, err := url.Parse(p.S3URL)
+			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+				fields = append(fields, "S3URL")
+			}
+		}
+		if p.PublicURL != "" {
+			u, err := url.Parse(p.PublicURL)
+			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+				fields = append(fields, "PublicURL")
+			}
+		}
 	case VolumeSnapshot:
 	}
 


### PR DESCRIPTION
Adds a check to `AWSProvider.Validate` to ensure that for S3URL and PublicURL, if set, have either HTTP or HTTPS as their scheme.

Also expands MigCluster's `validateURL` to check that the URL scheme is valid and that the URL is well formed.

Fixes https://github.com/fusor/mig-controller/issues/269

@jortel the AWS checks aren't where we talked about putting them, but after looking at the code for a while this seemed to make a little more sense to me. Curious what your opinion is.