### PR TITLE
migcluster: support using a custom CA bundle and insecure SSL connections

### DIFF
--- a/config/crds/migration_v1alpha1_migcluster.yaml
+++ b/config/crds/migration_v1alpha1_migcluster.yaml
@@ -33,6 +33,8 @@ spec:
             caBundle:
               format: byte
               type: string
+            insecureSkipTLSVerify:
+              type: boolean
             isHostCluster:
               type: boolean
             serviceAccountSecretRef:


### PR DESCRIPTION
This PR adds an `insecure` flag to the migcluster to support self-signed certificates. If `insecure` is false, then either the cluster's certificate must be trusted at a system level or provided via the `caBundle` option.

Fixes #91