### PR TITLE
Add support for limits.

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"github.com/fusor/mig-controller/pkg/settings"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -30,5 +31,11 @@ func AddToManager(m manager.Manager) error {
 			return err
 		}
 	}
+	// Application settings.
+	err := settings.Settings.Load()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -18,6 +18,7 @@ package migplan
 
 import (
 	"context"
+	"github.com/fusor/mig-controller/pkg/settings"
 	"strconv"
 
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
@@ -35,6 +36,9 @@ import (
 )
 
 var log = logging.WithName("plan")
+
+// Application settings.
+var Settings = &settings.Settings
 
 // Add creates a new MigPlan Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/pkg/controller/migplan/validation.go
+++ b/pkg/controller/migplan/validation.go
@@ -2,6 +2,8 @@ package migplan
 
 import (
 	"context"
+	"fmt"
+	"k8s.io/apimachinery/pkg/fields"
 	"reflect"
 	"strings"
 
@@ -10,6 +12,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Types
@@ -25,6 +28,8 @@ const (
 	InvalidDestinationCluster      = "InvalidDestinationCluster"
 	NsNotFoundOnSourceCluster      = "NamespaceNotFoundOnSourceCluster"
 	NsNotFoundOnDestinationCluster = "NamespaceNotFoundOnDestinationCluster"
+	NsLimitExceeded                = "NamespaceLimitExceeded"
+	PodLimitExceeded               = "PodLimitExceeded"
 	PlanConflict                   = "PlanConflict"
 	PvInvalidAction                = "PvInvalidAction"
 	PvNoSupportedAction            = "PvNoSupportedAction"
@@ -36,6 +41,7 @@ const (
 	PvInvalidCopyMethod            = "PvInvalidCopyMethod"
 	PvNoCopyMethodSelection        = "PvNoCopyMethodSelection"
 	PvWarnCopyMethodSnapshot       = "PvWarnCopyMethodSnapshot"
+	PvLimitExceeded                = "PvLimitExceeded"
 	StorageEnsured                 = "StorageEnsured"
 	RegistriesEnsured              = "RegistriesEnsured"
 	PvsDiscovered                  = "PvsDiscovered"
@@ -52,12 +58,13 @@ const (
 
 // Reasons
 const (
-	NotSet      = "NotSet"
-	NotFound    = "NotFound"
-	NotDistinct = "NotDistinct"
-	NotDone     = "NotDone"
-	Done        = "Done"
-	Conflict    = "Conflict"
+	NotSet        = "NotSet"
+	NotFound      = "NotFound"
+	NotDistinct   = "NotDistinct"
+	LimitExceeded = "LimitExceeded"
+	NotDone       = "NotDone"
+	Done          = "Done"
+	Conflict      = "Conflict"
 )
 
 // Statuses
@@ -80,6 +87,8 @@ const (
 	InvalidDestinationClusterMessage      = "The `srcMigClusterRef` and `dstMigClusterRef` cannot be the same."
 	NsNotFoundOnSourceClusterMessage      = "Namespaces [] not found on the source cluster."
 	NsNotFoundOnDestinationClusterMessage = "Namespaces [] not found on the destination cluster."
+	NsLimitExceededMessage                = "Namespace limit: %d exceeded, found:%d."
+	PodLimitExceededMessage               = "Pod limit: %d exceeded, found: %d."
 	PlanConflictMessage                   = "The plan is in conflict with []."
 	PvInvalidActionMessage                = "PV in `persistentVolumes` [] has an unsupported `action`."
 	PvNoSupportedActionMessage            = "PV in `persistentVolumes` [] with no `SupportedActions`."
@@ -91,6 +100,7 @@ const (
 	PvInvalidCopyMethodMessage            = "PV in `persistentVolumes` [] has an invalid `copyMethod`."
 	PvNoCopyMethodSelectionMessage        = "PV in `persistentVolumes` [] has no `Selected.CopyMethod`."
 	PvWarnCopyMethodSnapshotMessage       = "CopyMethod for PV in `persistentVolumes` [] is set to `snapshot`. Make sure that the chosen storage class is compatible with the source volume's storage type for Snapshot support."
+	PvLimitExceededMessage                = "PV limit: %d exceeded, found: %d."
 	StorageEnsuredMessage                 = "The storage resources have been created."
 	RegistriesEnsuredMessage              = "The migration registry resources have been created."
 	PvsDiscoveredMessage                  = "The `persistentVolumes` list has been updated with discovered PVs."
@@ -125,6 +135,13 @@ func (r ReconcileMigPlan) validate(plan *migapi.MigPlan) error {
 
 	// Migrated namespaces.
 	err = r.validateNamespaces(plan)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+
+	// Pod limit within each namespace.
+	err = r.validatePodLimit(plan)
 	if err != nil {
 		log.Trace(err)
 		return err
@@ -197,7 +214,8 @@ func (r ReconcileMigPlan) validateStorage(plan *migapi.MigPlan) error {
 
 // Validate the referenced assetCollection.
 func (r ReconcileMigPlan) validateNamespaces(plan *migapi.MigPlan) error {
-	if len(plan.Spec.Namespaces) == 0 {
+	count := len(plan.Spec.Namespaces)
+	if count == 0 {
 		plan.Status.SetCondition(migapi.Condition{
 			Type:     NsListEmpty,
 			Status:   True,
@@ -205,6 +223,69 @@ func (r ReconcileMigPlan) validateNamespaces(plan *migapi.MigPlan) error {
 			Message:  NsListEmptyMessage,
 		})
 		return nil
+	}
+	limit := Settings.Plan.NsLimit
+	if count > limit {
+		message := fmt.Sprintf(NsLimitExceededMessage, limit, count)
+		plan.Status.SetCondition(migapi.Condition{
+			Type:     NsLimitExceeded,
+			Status:   True,
+			Reason:   LimitExceeded,
+			Category: Critical,
+			Message:  message,
+		})
+		return nil
+	}
+
+	return nil
+}
+
+// Validate the total number of running pods (limit) across namespaces.
+func (r ReconcileMigPlan) validatePodLimit(plan *migapi.MigPlan) error {
+	if plan.Status.HasAnyCondition(Suspended, NsLimitExceeded) {
+		plan.Status.StageCondition(PodLimitExceeded)
+		return nil
+	}
+	cluster, err := plan.GetSourceCluster(r)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	if cluster == nil || !cluster.Status.IsReady() {
+		return nil
+	}
+	client, err := cluster.GetClient(r)
+	if err != nil {
+		log.Trace(err)
+		return err
+	}
+	count := 0
+	limit := Settings.Plan.PodLimit
+	for _, name := range plan.GetSourceNamespaces() {
+		list := kapi.PodList{}
+		options := k8sclient.ListOptions{
+			FieldSelector: fields.SelectorFromSet(
+				fields.Set{
+					"status.phase": string(kapi.PodRunning),
+				}),
+			Namespace: name,
+		}
+		err := client.List(context.TODO(), &options, &list)
+		if err != nil {
+			log.Trace(err)
+			return err
+		}
+		count += len(list.Items)
+	}
+	if count > limit {
+		message := fmt.Sprintf(PodLimitExceededMessage, limit, count)
+		plan.Status.SetCondition(migapi.Condition{
+			Type:     PodLimitExceeded,
+			Status:   True,
+			Reason:   LimitExceeded,
+			Category: Warn,
+			Message:  message,
+		})
 	}
 
 	return nil
@@ -320,9 +401,6 @@ func (r ReconcileMigPlan) validateDestinationCluster(plan *migapi.MigPlan) error
 
 // Validate required namespaces.
 func (r ReconcileMigPlan) validateRequiredNamespaces(plan *migapi.MigPlan) error {
-	if plan.Status.HasAnyCondition(Suspended) {
-		return nil
-	}
 	err := r.validateSourceNamespaces(plan)
 	if err != nil {
 		log.Trace(err)
@@ -341,7 +419,8 @@ func (r ReconcileMigPlan) validateRequiredNamespaces(plan *migapi.MigPlan) error
 // Returns error and the total error conditions set.
 func (r ReconcileMigPlan) validateSourceNamespaces(plan *migapi.MigPlan) error {
 	namespaces := []string{migapi.VeleroNamespace}
-	if plan.Status.HasAnyCondition(Suspended) {
+	if plan.Status.HasAnyCondition(Suspended, NsLimitExceeded) {
+		plan.Status.StageCondition(NsNotFoundOnSourceCluster)
 		return nil
 	}
 	for _, ns := range plan.Spec.Namespaces {

--- a/pkg/settings/plan.go
+++ b/pkg/settings/plan.go
@@ -1,0 +1,37 @@
+package settings
+
+// Environment variables.
+const (
+	NsLimit  = "NAMESPACE_LIMIT"
+	PodLimit = "POD_LIMIT"
+	PvLimit  = "PV_LIMIT"
+)
+
+// Plan settings.
+//   NsLimit: Maximum number of namespaces on a Plan.
+//   PodLimit: Maximum number of Pods across namespaces.
+//   PvLimit: Maximum number PVs on a Plan.
+type Plan struct {
+	NsLimit  int
+	PodLimit int
+	PvLimit  int
+}
+
+// Load settings.
+func (r *Plan) Load() error {
+	var err error
+	r.NsLimit, err = getEnvLimit(NsLimit, 10)
+	if err != nil {
+		return err
+	}
+	r.PodLimit, err = getEnvLimit(PodLimit, 100)
+	if err != nil {
+		return err
+	}
+	r.PvLimit, err = getEnvLimit(PvLimit, 100)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -1,0 +1,42 @@
+package settings
+
+import (
+	"errors"
+	"os"
+	"strconv"
+)
+
+// Global
+var Settings = _Settings{}
+
+// Settings
+//   Plan: Plan settings.
+type _Settings struct {
+	Plan Plan
+}
+
+// Load settings.
+func (r *_Settings) Load() error {
+	err := r.Plan.Load()
+	return err
+}
+
+// Get positive integer limit from the environment
+// using the specified variable name and default.
+func getEnvLimit(name string, def int) (int, error) {
+	limit := 0
+	if s, found := os.LookupEnv(name); found {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, errors.New(name + " must be an integer")
+		}
+		if n < 1 {
+			return 0, errors.New(name + " must be >= 1")
+		}
+		limit = n
+	} else {
+		limit = def
+	}
+
+	return limit, nil
+}


### PR DESCRIPTION
Support general concept of _Application Settings_ loaded from environment variables mounted from _ConfigMap_ managed by the operator. 

Add support for migration Plan limits for:
- Total number of namespaces listed on the Plan.  When exceeded:
  - Set `Critical` condition.
  - [SKIP] Validate namespaces (exist) on the source cluster.
  - [SKIP] Validate pod limit.
  - [SKIP] PV discovery.
- Total number of _running_ pods each namespace. When exceeded:
  - Set `Warn` condition.
- Total number and PVs listed on the Plan (as discovered). When exceeded:
  - Set `Warn` condition.

In the future: the supported settings can be expanded to include a number of things we currently have hard coded constants for in the controller such as the _VeleroNamespace_.  Also, the limits can be expanded and/or refined.
