### PR TITLE
Return after setting error for creds validation to avoid nil segfault

### DIFF
--- a/pkg/controller/migstorage/validation.go
+++ b/pkg/controller/migstorage/validation.go
@@ -108,6 +108,7 @@ func (r ReconcileMigStorage) validateBackupStorage(storage *migapi.MigStorage) e
 			Category: Critical,
 			Message:  InvalidBSCredsSecretRefMessage,
 		})
+		return nil
 	}
 
 	// Secret
@@ -126,6 +127,7 @@ func (r ReconcileMigStorage) validateBackupStorage(storage *migapi.MigStorage) e
 			Category: Critical,
 			Message:  InvalidBSCredsSecretRefMessage,
 		})
+		return nil
 	}
 
 	// Fields
@@ -194,6 +196,7 @@ func (r ReconcileMigStorage) validateVolumeSnapshotStorage(storage *migapi.MigSt
 				Category: Critical,
 				Message:  InvalidVSCredsSecretRefMessage,
 			})
+			return nil
 		}
 
 		// NotFound
@@ -205,6 +208,7 @@ func (r ReconcileMigStorage) validateVolumeSnapshotStorage(storage *migapi.MigSt
 				Category: Critical,
 				Message:  InvalidVSCredsSecretRefMessage,
 			})
+			return nil
 		}
 
 		// Fields


### PR DESCRIPTION
After not finding the secret, the validation code was setting a critical
condition for the missing secret, and then going on to the next line
attempting to validate the (non-existent) secret, causing the controller
to crash.

This commit adds the appropriate return statements after setting critical
validation conditions related to the secret so that we don't attempt further
validation on the secret.