### PR TITLE
Support setting a custom CA bundle for S3-compatible storage

### DIFF
--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -87,11 +87,11 @@ type BackupStorageConfig struct {
 	AwsPublicURL          string                `json:"awsPublicUrl,omitempty"`
 	AwsKmsKeyID           string                `json:"awsKmsKeyId,omitempty"`
 	AwsSignatureVersion   string                `json:"awsSignatureVersion,omitempty"`
+	S3CustomCABundle      []byte                `json:"s3CustomCABundle,omitempty"`
 	AzureStorageAccount   string                `json:"azureStorageAccount,omitempty"`
 	AzureStorageContainer string                `json:"azureStorageContainer,omitempty"`
 	AzureResourceGroup    string                `json:"azureResourceGroup,omitempty"`
 	GcpBucket             string                `json:"gcpBucket,omitempty"`
-	AwsCustomCABundle     []byte                `json:"awsCustomCABundle,omitempty"`
 }
 
 func init() {
@@ -273,7 +273,7 @@ func (r *BackupStorageConfig) GetProvider(name string) pvdr.Provider {
 			KMSKeyId:         r.AwsKmsKeyID,
 			SignatureVersion: r.AwsSignatureVersion,
 			S3ForcePathStyle: r.AwsS3ForcePathStyle,
-			CustomCABundle:   r.AwsCustomCABundle,
+			CustomCABundle:   r.S3CustomCABundle,
 		}
 	case Azure:
 		provider = &pvdr.AzureProvider{

--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -91,6 +91,7 @@ type BackupStorageConfig struct {
 	AzureStorageContainer string                `json:"azureStorageContainer,omitempty"`
 	AzureResourceGroup    string                `json:"azureResourceGroup,omitempty"`
 	GcpBucket             string                `json:"gcpBucket,omitempty"`
+	AwsCustomCABundle     []byte                `json:"awsCustomCABundle,omitempty"`
 }
 
 func init() {
@@ -272,6 +273,7 @@ func (r *BackupStorageConfig) GetProvider(name string) pvdr.Provider {
 			KMSKeyId:         r.AwsKmsKeyID,
 			SignatureVersion: r.AwsSignatureVersion,
 			S3ForcePathStyle: r.AwsS3ForcePathStyle,
+			CustomCABundle:   r.AwsCustomCABundle,
 		}
 	case Azure:
 		provider = &pvdr.AzureProvider{

--- a/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
@@ -32,8 +32,8 @@ func (in *BackupStorageConfig) DeepCopyInto(out *BackupStorageConfig) {
 		*out = new(v1.ObjectReference)
 		**out = **in
 	}
-	if in.AwsCustomCABundle != nil {
-		in, out := &in.AwsCustomCABundle, &out.AwsCustomCABundle
+	if in.S3CustomCABundle != nil {
+		in, out := &in.S3CustomCABundle, &out.S3CustomCABundle
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
@@ -32,6 +32,11 @@ func (in *BackupStorageConfig) DeepCopyInto(out *BackupStorageConfig) {
 		*out = new(v1.ObjectReference)
 		**out = **in
 	}
+	if in.AwsCustomCABundle != nil {
+		in, out := &in.AwsCustomCABundle, &out.AwsCustomCABundle
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
This adds a `AwsCustomCABundle` field to the BackupStorageConfig definition, which accepts a base64 encoded CA bundle that will be used instead of the system-provided certs to validate HTTPS connections to the S3-compatible storage.

I might just be missing it, but it appears the aws-sdk for Go does not support SSL-without-verification, so connecting to an endpoint with a self-signed cert would require that a CA bundle be provided here.

For reference, documentation on the behavior of the aws-sdk session's CustomCABundle option can be found here: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/

Fixes #270