### PR TITLE
Adds support for Azure snapshots

### DIFF
--- a/config/crds/migration_v1alpha1_migcluster.yaml
+++ b/config/crds/migration_v1alpha1_migcluster.yaml
@@ -28,6 +28,8 @@ spec:
           type: object
         spec:
           properties:
+            azureResourceGroup:
+              type: string
             caBundle:
               format: byte
               type: string

--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	pvdr "github.com/fusor/mig-controller/pkg/cloudprovider"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"time"
@@ -46,6 +47,7 @@ type MigClusterSpec struct {
 	ServiceAccountSecretRef *kapi.ObjectReference `json:"serviceAccountSecretRef,omitempty"`
 	CABundle                []byte                `json:"caBundle,omitempty"`
 	StorageClasses          []StorageClass        `json:"storageClasses,omitempty"`
+	AzureResourceGroup      string                `json:"azureResourceGroup,omitempty"`
 }
 
 // MigClusterStatus defines the observed state of MigCluster
@@ -316,4 +318,14 @@ func (r *MigCluster) GetStorageClasses(client k8sclient.Client) ([]storageapi.St
 		return nil, err
 	}
 	return list.Items, nil
+}
+
+func (r *MigCluster) UpdateProvider(provider pvdr.Provider) {
+	switch provider.GetName() {
+	case pvdr.Azure:
+		p, cast := provider.(*pvdr.AzureProvider)
+		if cast {
+			p.ClusterResourceGroup = r.Spec.AzureResourceGroup
+		}
+	}
 }

--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -21,7 +21,6 @@ import (
 
 	pvdr "github.com/fusor/mig-controller/pkg/cloudprovider"
 	velero "github.com/heptio/velero/pkg/apis/velero/v1"
-	"github.com/pkg/errors"
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -109,14 +108,7 @@ func (r *MigStorage) BuildBSL() *velero.BackupStorageLocation {
 		},
 	}
 
-	r.UpdateBSL(bsl)
 	return bsl
-}
-
-// Update BSL.
-func (r *MigStorage) UpdateBSL(bsl *velero.BackupStorageLocation) {
-	provider := r.GetBackupStorageProvider()
-	provider.UpdateBSL(bsl)
 }
 
 // Build VSL.
@@ -132,18 +124,11 @@ func (r *MigStorage) BuildVSL(planUID string) *velero.VolumeSnapshotLocation {
 		},
 	}
 
-	r.UpdateVSL(vsl)
 	return vsl
 }
 
-// Update VSL.
-func (r *MigStorage) UpdateVSL(vsl *velero.VolumeSnapshotLocation) {
-	provider := r.GetVolumeSnapshotProvider()
-	provider.UpdateVSL(vsl)
-}
-
 // Build backup cloud-secret.
-func (r *MigStorage) BuildBSLCloudSecret(client k8sclient.Client) (*kapi.Secret, error) {
+func (r *MigStorage) BuildBSLCloudSecret() *kapi.Secret {
 	secret := &kapi.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:    r.GetCorrelationLabels(),
@@ -152,26 +137,11 @@ func (r *MigStorage) BuildBSLCloudSecret(client k8sclient.Client) (*kapi.Secret,
 		},
 	}
 
-	err := r.UpdateBSLCloudSecret(client, secret)
-	return secret, err
-}
-
-// Update backup cloud-secret.
-func (r *MigStorage) UpdateBSLCloudSecret(client k8sclient.Client, cloudSecret *kapi.Secret) error {
-	secret, err := r.GetBackupStorageCredSecret(client)
-	if err != nil {
-		return err
-	}
-	if secret == nil {
-		return errors.New("Credentials secret not found.")
-	}
-	provider := r.GetBackupStorageProvider()
-	provider.UpdateCloudSecret(secret, cloudSecret)
-	return nil
+	return secret
 }
 
 // Build snapshot cloud-secret.
-func (r *MigStorage) BuildVSLCloudSecret(client k8sclient.Client) (*kapi.Secret, error) {
+func (r *MigStorage) BuildVSLCloudSecret() *kapi.Secret {
 	secret := &kapi.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:    r.GetCorrelationLabels(),
@@ -180,22 +150,7 @@ func (r *MigStorage) BuildVSLCloudSecret(client k8sclient.Client) (*kapi.Secret,
 		},
 	}
 
-	err := r.UpdateVSLCloudSecret(client, secret)
-	return secret, err
-}
-
-// Update snapshot cloud-secret.
-func (r *MigStorage) UpdateVSLCloudSecret(client k8sclient.Client, cloudSecret *kapi.Secret) error {
-	secret, err := r.GetVolumeSnapshotCredSecret(client)
-	if err != nil {
-		return err
-	}
-	if secret == nil {
-		return errors.New("Credentials secret not found.")
-	}
-	provider := r.GetBackupStorageProvider()
-	provider.UpdateCloudSecret(secret, cloudSecret)
-	return nil
+	return secret
 }
 
 // Determine if two BSLs are equal based on relevant fields in the Spec.
@@ -265,6 +220,7 @@ func (r *BackupStorageConfig) GetProvider(name string) pvdr.Provider {
 		provider = &pvdr.AWSProvider{
 			BaseProvider: pvdr.BaseProvider{
 				Role: pvdr.BackupStorage,
+				Name: name,
 			},
 			Region:           r.AwsRegion,
 			Bucket:           r.AwsBucketName,
@@ -279,6 +235,7 @@ func (r *BackupStorageConfig) GetProvider(name string) pvdr.Provider {
 		provider = &pvdr.AzureProvider{
 			BaseProvider: pvdr.BaseProvider{
 				Role: pvdr.BackupStorage,
+				Name: name,
 			},
 			ResourceGroup:    r.AzureResourceGroup,
 			StorageAccount:   r.AzureStorageAccount,
@@ -288,6 +245,7 @@ func (r *BackupStorageConfig) GetProvider(name string) pvdr.Provider {
 		provider = &pvdr.GCPProvider{
 			BaseProvider: pvdr.BaseProvider{
 				Role: pvdr.BackupStorage,
+				Name: name,
 			},
 			Bucket: r.GcpBucket,
 		}

--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -94,7 +94,7 @@ func (p *AWSProvider) UpdateVSL(vsl *velero.VolumeSnapshotLocation) {
 	}
 }
 
-func (p *AWSProvider) UpdateCloudSecret(secret, cloudSecret *kapi.Secret) {
+func (p *AWSProvider) UpdateCloudSecret(secret, cloudSecret *kapi.Secret) error {
 	cloudSecret.Data = map[string][]byte{
 		"cloud": []byte(
 			fmt.Sprintf(
@@ -103,6 +103,7 @@ func (p *AWSProvider) UpdateCloudSecret(secret, cloudSecret *kapi.Secret) {
 				secret.Data[AwsSecretAccessKey]),
 		),
 	}
+	return nil
 }
 
 func (p *AWSProvider) UpdateRegistrySecret(secret, registrySecret *kapi.Secret) error {

--- a/pkg/cloudprovider/gcp.go
+++ b/pkg/cloudprovider/gcp.go
@@ -39,10 +39,11 @@ func (p *GCPProvider) UpdateVSL(vsl *velero.VolumeSnapshotLocation) {
 	vsl.Spec.Provider = GCP
 }
 
-func (p *GCPProvider) UpdateCloudSecret(secret, cloudSecret *kapi.Secret) {
+func (p *GCPProvider) UpdateCloudSecret(secret, cloudSecret *kapi.Secret) error {
 	cloudSecret.Data = map[string][]byte{
 		"cloud": secret.Data[GcpCredentials],
 	}
+	return nil
 }
 
 func (p *GCPProvider) UpdateRegistrySecret(secret, registrySecret *kapi.Secret) error {

--- a/pkg/cloudprovider/provider.go
+++ b/pkg/cloudprovider/provider.go
@@ -20,10 +20,11 @@ const (
 )
 
 type Provider interface {
+	GetName() string
 	SetRole(role string)
 	UpdateBSL(location *velero.BackupStorageLocation)
 	UpdateVSL(location *velero.VolumeSnapshotLocation)
-	UpdateCloudSecret(secret, cloudSecret *kapi.Secret)
+	UpdateCloudSecret(secret, cloudSecret *kapi.Secret) error
 	UpdateRegistrySecret(secret, registrySecret *kapi.Secret) error
 	UpdateRegistryDC(dc *appsv1.DeploymentConfig, name, dirName string)
 	Validate(secret *kapi.Secret) []string
@@ -31,9 +32,14 @@ type Provider interface {
 }
 
 type BaseProvider struct {
+	Name string
 	Role string
 }
 
 func (p *BaseProvider) SetRole(role string) {
 	p.Role = role
+}
+
+func (p *BaseProvider) GetName() string {
+	return p.Name
 }


### PR DESCRIPTION
1) Adds Spec.AzureResourceGroup to migcluster, required to be set
   on both src and dest when using Azure snapshots
2) Refactors the migstorage/cloudprovider code to allow for
   provider-specific fields from migcluster to be added to
   the cloudprovider before generating the velero secret
3) Adds logic to the azure UpdateCloudSecret method to pull
   cluster.Spec.AzureResource group, if present, into the velero
   secret for the cluster.