### PR TITLE
Add s3CustomCABundle to migstorage crd schema

### DIFF
--- a/config/crds/migration_v1alpha1_migstorage.yaml
+++ b/config/crds/migration_v1alpha1_migstorage.yaml
@@ -54,6 +54,9 @@ spec:
                   type: object
                 gcpBucket:
                   type: string
+                s3CustomCABundle:
+                  format: byte
+                  type: string
               type: object
             backupStorageProvider:
               type: string


### PR DESCRIPTION
I missed this while working on https://github.com/fusor/mig-controller/pull/354, it should have been included there.