### PR TITLE
separate cred secrets for azure/gcp/aws

### DIFF
--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strings"
 
+	pvdr "github.com/fusor/mig-controller/pkg/cloudprovider"
 	migref "github.com/fusor/mig-controller/pkg/reference"
 	velero "github.com/heptio/velero/pkg/apis/velero/v1"
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -562,13 +563,13 @@ func (r *MigPlan) GetVSL(client k8sclient.Client) (*velero.VolumeSnapshotLocatio
 	return nil, nil
 }
 
-// Get the cloud credentials secret by labels.
-func (r *MigPlan) GetCloudSecret(client k8sclient.Client) (*kapi.Secret, error) {
+// Get the cloud credentials secret by labels for the provider.
+func (r *MigPlan) GetCloudSecret(client k8sclient.Client, provider pvdr.Provider) (*kapi.Secret, error) {
 	return GetSecret(
 		client,
 		&kapi.ObjectReference{
 			Namespace: VeleroNamespace,
-			Name:      VeleroCloudSecret,
+			Name:      provider.GetCloudSecretName(),
 		})
 }
 

--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -134,7 +134,7 @@ func (r *MigStorage) BuildBSLCloudSecret() *kapi.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:    r.GetCorrelationLabels(),
 			Namespace: VeleroNamespace,
-			Name:      VeleroCloudSecret,
+			Name:      r.GetBackupStorageProvider().GetCloudSecretName(),
 		},
 	}
 
@@ -147,7 +147,7 @@ func (r *MigStorage) BuildVSLCloudSecret() *kapi.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:    r.GetCorrelationLabels(),
 			Namespace: VeleroNamespace,
-			Name:      VeleroCloudSecret,
+			Name:      r.GetVolumeSnapshotProvider().GetCloudSecretName(),
 		},
 	}
 
@@ -268,6 +268,7 @@ func (r *VolumeSnapshotConfig) GetProvider(name string) pvdr.Provider {
 		provider = &pvdr.AWSProvider{
 			BaseProvider: pvdr.BaseProvider{
 				Role: pvdr.VolumeSnapshot,
+				Name: name,
 			},
 			Region:                  r.AwsRegion,
 			SnapshotCreationTimeout: r.SnapshotCreationTimeout,
@@ -276,6 +277,7 @@ func (r *VolumeSnapshotConfig) GetProvider(name string) pvdr.Provider {
 		provider = &pvdr.AzureProvider{
 			BaseProvider: pvdr.BaseProvider{
 				Role: pvdr.VolumeSnapshot,
+				Name: name,
 			},
 			ResourceGroup:           r.AzureResourceGroup,
 			APITimeout:              r.AzureAPITimeout,
@@ -285,6 +287,7 @@ func (r *VolumeSnapshotConfig) GetProvider(name string) pvdr.Provider {
 		provider = &pvdr.GCPProvider{
 			BaseProvider: pvdr.BaseProvider{
 				Role: pvdr.VolumeSnapshot,
+				Name: name,
 			},
 			SnapshotCreationTimeout: r.SnapshotCreationTimeout,
 		}

--- a/pkg/apis/migration/v1alpha1/resource.go
+++ b/pkg/apis/migration/v1alpha1/resource.go
@@ -5,9 +5,8 @@ import (
 )
 
 const (
-	TouchAnnotation   = "touch"
-	VeleroNamespace   = "openshift-migration"
-	VeleroCloudSecret = "cloud-credentials"
+	TouchAnnotation = "touch"
+	VeleroNamespace = "openshift-migration"
 )
 
 // Migration application CR.

--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -23,8 +23,10 @@ import (
 
 // Credentials Secret.
 const (
-	AwsAccessKeyId     = "aws-access-key-id"
-	AwsSecretAccessKey = "aws-secret-access-key"
+	AwsAccessKeyId          = "aws-access-key-id"
+	AwsSecretAccessKey      = "aws-secret-access-key"
+	AwsCloudSecretName      = "cloud-credentials"
+	AwsCloudCredentialsPath = "credentials/cloud"
 )
 
 // S3 constants
@@ -63,6 +65,13 @@ func (p *AWSProvider) GetURL() string {
 	return ""
 }
 
+func (p *AWSProvider) GetCloudSecretName() string {
+	return AwsCloudSecretName
+}
+
+func (p *AWSProvider) GetCloudCredentialsPath() string {
+	return AwsCloudCredentialsPath
+}
 func (p *AWSProvider) UpdateBSL(bsl *velero.BackupStorageLocation) {
 	bsl.Spec.Provider = AWS
 	bsl.Spec.StorageType = velero.StorageType{

--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -21,7 +21,9 @@ import (
 
 // Credentials secret.
 const (
-	AzureCredentials = "azure-credentials"
+	AzureCredentials          = "azure-credentials"
+	AzureCloudSecretName      = "azure-cloud-credentials"
+	AzureCloudCredentialsPath = "credentials-azure/cloud"
 
 	tenantIDKey             = "AZURE_TENANT_ID"
 	subscriptionIDKey       = "AZURE_SUBSCRIPTION_ID"
@@ -46,6 +48,13 @@ type AzureProvider struct {
 	SnapshotCreationTimeout string
 }
 
+func (p *AzureProvider) GetCloudSecretName() string {
+	return AzureCloudSecretName
+}
+
+func (p *AzureProvider) GetCloudCredentialsPath() string {
+	return AzureCloudCredentialsPath
+}
 func (p *AzureProvider) UpdateBSL(bsl *velero.BackupStorageLocation) {
 	bsl.Spec.Provider = Azure
 	bsl.Spec.StorageType = velero.StorageType{

--- a/pkg/cloudprovider/gcp.go
+++ b/pkg/cloudprovider/gcp.go
@@ -14,7 +14,9 @@ import (
 
 // Credentials secret.
 const (
-	GcpCredentials = "gcp-credentials"
+	GcpCredentials          = "gcp-credentials"
+	GcpCloudSecretName      = "gcp-cloud-credentials"
+	GcpCloudCredentialsPath = "credentials-gcp/cloud"
 )
 
 type GCPProvider struct {
@@ -22,6 +24,14 @@ type GCPProvider struct {
 	Bucket                  string
 	KMSKeyId                string
 	SnapshotCreationTimeout string
+}
+
+func (p *GCPProvider) GetCloudSecretName() string {
+	return GcpCloudSecretName
+}
+
+func (p *GCPProvider) GetCloudCredentialsPath() string {
+	return GcpCloudCredentialsPath
 }
 
 func (p *GCPProvider) UpdateBSL(bsl *velero.BackupStorageLocation) {

--- a/pkg/cloudprovider/provider.go
+++ b/pkg/cloudprovider/provider.go
@@ -21,6 +21,8 @@ const (
 
 type Provider interface {
 	GetName() string
+	GetCloudSecretName() string
+	GetCloudCredentialsPath() string
 	SetRole(role string)
 	UpdateBSL(location *velero.BackupStorageLocation)
 	UpdateVSL(location *velero.VolumeSnapshotLocation)


### PR DESCRIPTION
This allows for aws, gcp, and azure cred secrets to coexist on the same velero instance. Only one set of credentials per provider is still a limitation, but this allows the use of multiple providers at once for a given controller instance.

This PR requires a (forthcoming) mig-operator PR for azure/gcp use, since without it velero won't look in the right location for (or mount) those provider secrets.