### PR TITLE
Test NFS accessibility.

### DIFF
--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -657,16 +657,19 @@ const (
 // Name - The PV name.
 // Capacity - The PV storage capacity.
 // StorageClass - The PV storage class name.
-// Supported - Lists of what is supported
-// Selection - Choices made from supported
+// Supported - Lists of what is supported.
+// Selection - Choices made from supported.
+// PVC - Associated PVC.
+// NFS - NFS properties.
 // staged - A PV has been explicitly added/updated.
 type PV struct {
-	Name         string            `json:"name,omitempty"`
-	Capacity     resource.Quantity `json:"capacity,omitempty"`
-	StorageClass string            `json:"storageClass,omitempty"`
-	Supported    Supported         `json:"supported"`
-	Selection    Selection         `json:"selection"`
-	PVC          PVC               `json:"pvc,omitempty"`
+	Name         string                `json:"name,omitempty"`
+	Capacity     resource.Quantity     `json:"capacity,omitempty"`
+	StorageClass string                `json:"storageClass,omitempty"`
+	Supported    Supported             `json:"supported"`
+	Selection    Selection             `json:"selection"`
+	PVC          PVC                   `json:"pvc,omitempty"`
+	NFS          *kapi.NFSVolumeSource `json:"-"`
 	staged       bool
 }
 
@@ -704,6 +707,7 @@ func (r *PV) Update(pv PV) {
 	r.Supported.CopyMethods = pv.Supported.CopyMethods
 	r.Capacity = pv.Capacity
 	r.PVC = pv.PVC
+	r.NFS = pv.NFS
 	if len(r.Supported.Actions) == 1 {
 		r.Selection.Action = r.Supported.Actions[0]
 	}

--- a/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/migration/v1alpha1/zz_generated.deepcopy.go
@@ -534,6 +534,11 @@ func (in *PV) DeepCopyInto(out *PV) {
 	in.Supported.DeepCopyInto(&out.Supported)
 	out.Selection = in.Selection
 	in.PVC.DeepCopyInto(&out.PVC)
+	if in.NFS != nil {
+		in, out := &in.NFS, &out.NFS
+		*out = new(v1.NFSVolumeSource)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -225,6 +225,14 @@ func (r *ReconcileMigPlan) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{Requeue: true}, nil
 	}
 
+	// Validate NFS PV accessibility.
+	nfsValidation := NfsValidation{Plan: plan}
+	err = nfsValidation.Run(r.Client)
+	if err != nil {
+		log.Trace(err)
+		return reconcile.Result{Requeue: true}, nil
+	}
+
 	// Validate PV actions.
 	err = r.validatePvSelections(plan)
 	if err != nil {

--- a/pkg/controller/migplan/pvlist.go
+++ b/pkg/controller/migplan/pvlist.go
@@ -106,6 +106,7 @@ func (r *ReconcileMigPlan) updatePvs(plan *migapi.MigPlan) error {
 				},
 				Selection: selection,
 				PVC:       claim,
+				NFS:       pv.Spec.NFS,
 			})
 	}
 


### PR DESCRIPTION
Issue: https://github.com/fusor/mig-controller/issues/214

Test NFS server accessibility on the destination cluster by performing a connection check on port 2049.
When the controller is running on the destination, the test is performed directly by the controller.  Else, the test is performed by running (pod exec) the `nc` command.  For convenience, one of the velero pods is used.  This requires: https://github.com/fusor/velero/pull/39.  if not suitable pods can be found, an `Error` condition is set.

When an NFS server cannot be accessed, the `move` action is removed from the PV supported actions list and a `Warn` condition is set.
