### PR TITLE
Add Prometheus metrics to track high level aggregate progress of migrations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -478,6 +478,7 @@
   packages = [
     "prometheus",
     "prometheus/internal",
+    "prometheus/promauto",
     "prometheus/promhttp",
   ]
   pruneopts = "T"
@@ -1229,6 +1230,9 @@
     "github.com/openshift/api/project/v1",
     "github.com/openshift/api/route/v1",
     "github.com/pkg/errors",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promauto",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     "golang.org/x/net/context",
     "google.golang.org/api/option",
     "k8s.io/api/apps/v1beta1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,6 +20,9 @@ required = [
     "github.com/openshift/api/build/v1",
     "github.com/openshift/api/route/v1",
     "github.com/openshift/api/network/v1",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promauto",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     ]
 
 [prune]

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,12 +17,14 @@ limitations under the License.
 package main
 
 import (
+	"net/http"
 	"os"
 
 	"github.com/fusor/mig-controller/pkg/apis"
 	"github.com/fusor/mig-controller/pkg/controller"
 	"github.com/fusor/mig-controller/pkg/webhook"
 	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	clusterregv1alpha1 "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -34,6 +36,11 @@ import (
 func main() {
 	logf.SetLogger(logf.ZapLogger(false))
 	log := logf.Log.WithName("entrypoint")
+
+	// Start prometheus metrics HTTP handler
+	log.Info("setting up prometheus endpoint :2112/metrics")
+	http.Handle("/metrics", promhttp.Handler())
+	go http.ListenAndServe(":2112", nil)
 
 	// Get a config to talk to the apiserver
 	log.Info("setting up client for manager")

--- a/pkg/controller/migmigration/metrics.go
+++ b/pkg/controller/migmigration/metrics.go
@@ -50,7 +50,7 @@ func recordMetrics(client client.Client) {
 		idle      = "idle"
 		running   = "running"
 		completed = "completed"
-		failed    = "error"
+		failed    = "failed"
 	)
 
 	go func() {
@@ -70,7 +70,7 @@ func recordMetrics(client client.Client) {
 			var stageIdle, stageRunning, stageCompleted, stageFailed float64
 			var finalIdle, finalRunning, finalCompleted, finalFailed float64
 
-			// for all migmigrations, count # in idle, running, completed, error
+			// for all migmigrations, count # in idle, running, completed, failed
 			for _, m := range migrations {
 				// Stage
 				if m.Spec.Stage && m.Status.HasCondition(Running) {

--- a/pkg/controller/migmigration/metrics.go
+++ b/pkg/controller/migmigration/metrics.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2019 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migmigration
+
+import (
+	"time"
+
+	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	// 'status' - [ idle, running, completed, error ]
+	// 'type'   - [ stage, final ]
+	migrationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "mig_migrations",
+		Help: "Count of MigMigrations sorted by status and type",
+	},
+		[]string{"type", "status"},
+	)
+)
+
+func recordMetrics(client client.Client) {
+	const (
+		// Metrics const values
+		//   Separate from mig-controller consts to keep a stable interface for metrics systems
+		//   configured to pull from static metrics endpoints.
+
+		// Migration Type
+		stage = "stage"
+		final = "final"
+
+		// Migration Status
+		idle      = "idle"
+		running   = "running"
+		completed = "completed"
+		failed    = "error"
+	)
+
+	go func() {
+		for {
+			time.Sleep(10 * time.Second)
+
+			// get all migmigration objects
+			migrations, err := migapi.ListMigrations(client)
+
+			// if error occurs, retry 10 seconds later
+			if err != nil {
+				log.Trace(err)
+				continue
+			}
+
+			// Holding counter vars used to make gauge update "atomic"
+			var stageIdle, stageRunning, stageCompleted, stageFailed float64
+			var finalIdle, finalRunning, finalCompleted, finalFailed float64
+
+			// for all migmigrations, count # in idle, running, completed, error
+			for _, m := range migrations {
+				// Stage
+				if m.Spec.Stage && m.Status.HasCondition(Running) {
+					stageRunning++
+					continue
+				}
+				if m.Spec.Stage && m.Status.HasCondition(Succeeded) {
+					stageCompleted++
+					continue
+				}
+				if m.Spec.Stage && m.Status.HasCondition(Failed) {
+					stageFailed++
+					continue
+				}
+				if m.Spec.Stage {
+					stageIdle++
+					continue
+				}
+
+				// Final
+				if !m.Spec.Stage && m.Status.HasCondition(Running) {
+					finalRunning++
+					continue
+				}
+				if !m.Spec.Stage && m.Status.HasCondition(Succeeded) {
+					finalCompleted++
+					continue
+				}
+				if !m.Spec.Stage && m.Status.HasCondition(Failed) {
+					finalFailed++
+					continue
+				}
+				if !m.Spec.Stage {
+					finalIdle++
+					continue
+				}
+			}
+
+			// Stage
+			migrationGauge.With(
+				prometheus.Labels{"type": stage, "status": idle}).Set(stageIdle)
+			migrationGauge.With(
+				prometheus.Labels{"type": stage, "status": running}).Set(stageRunning)
+			migrationGauge.With(
+				prometheus.Labels{"type": stage, "status": completed}).Set(stageCompleted)
+			migrationGauge.With(
+				prometheus.Labels{"type": stage, "status": failed}).Set(stageFailed)
+
+			// Final
+			migrationGauge.With(
+				prometheus.Labels{"type": final, "status": idle}).Set(finalIdle)
+			migrationGauge.With(
+				prometheus.Labels{"type": final, "status": running}).Set(finalRunning)
+			migrationGauge.With(
+				prometheus.Labels{"type": final, "status": completed}).Set(finalCompleted)
+			migrationGauge.With(
+				prometheus.Labels{"type": final, "status": failed}).Set(finalFailed)
+		}
+	}()
+}

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -24,8 +24,6 @@ import (
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/fusor/mig-controller/pkg/logging"
 	migref "github.com/fusor/mig-controller/pkg/reference"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,17 +37,6 @@ import (
 )
 
 var log = logging.WithName("migration")
-
-var (
-	// 'status' - [ idle, running, completed, error ]
-	// 'type'   - [ stage, final ]
-	migrationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mig_migrations",
-		Help: "Count of MigMigrations sorted by status and type",
-	},
-		[]string{"type", "status"},
-	)
-)
 
 // Add creates a new MigMigration Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -128,98 +115,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 }
 
 var _ reconcile.Reconciler = &ReconcileMigMigration{}
-
-func recordMetrics(client client.Client) {
-	const (
-		// Metrics const values
-		//   Separate from mig-controller consts to keep a stable interface for metrics systems
-		//   configured to pull from static metrics endpoints.
-
-		// Migration Type
-		stage = "stage"
-		final = "final"
-
-		// Migration Status
-		idle      = "idle"
-		running   = "running"
-		completed = "completed"
-		failed    = "error"
-	)
-
-	go func() {
-		for {
-			time.Sleep(10 * time.Second)
-			// get all migmigration objects
-			migrations, err := migapi.ListMigrations(client)
-
-			// if error occurs, gracefully retry later
-			if err != nil {
-				log.Trace(err)
-				continue
-			}
-
-			// Holding counter vars used to make gauge update "atomic"
-			var stageIdle, stageRunning, stageCompleted, stageFailed float64
-			var finalIdle, finalRunning, finalCompleted, finalFailed float64
-
-			// for all migmigrations, count # in idle, running, completed, error
-			for _, m := range migrations {
-				// Stage
-				if m.Spec.Stage && m.Status.HasCondition(Running) {
-					stageRunning++
-					continue
-				}
-				if m.Spec.Stage && m.Status.HasCondition(Succeeded) {
-					stageCompleted++
-					continue
-				}
-				if m.Spec.Stage && m.Status.HasCondition(Failed) {
-					stageFailed++
-					continue
-				}
-				if m.Spec.Stage {
-					stageIdle++
-					continue
-				}
-
-				// Final
-				if !m.Spec.Stage && m.Status.HasCondition(Running) {
-					finalRunning++
-					continue
-				}
-				if !m.Spec.Stage && m.Status.HasCondition(Succeeded) {
-					finalCompleted++
-					continue
-				}
-				if !m.Spec.Stage && m.Status.HasCondition(Failed) {
-					finalFailed++
-				}
-				if !m.Spec.Stage {
-					finalIdle++
-				}
-			}
-
-			// Stage
-			migrationGauge.With(
-				prometheus.Labels{"type": stage, "status": idle}).Set(stageIdle)
-			migrationGauge.With(
-				prometheus.Labels{"type": stage, "status": running}).Set(stageRunning)
-			migrationGauge.With(
-				prometheus.Labels{"type": stage, "status": completed}).Set(stageCompleted)
-			migrationGauge.With(
-				prometheus.Labels{"type": stage, "status": failed}).Set(stageFailed)
-			// Final
-			migrationGauge.With(
-				prometheus.Labels{"type": final, "status": idle}).Set(finalIdle)
-			migrationGauge.With(
-				prometheus.Labels{"type": final, "status": running}).Set(finalRunning)
-			migrationGauge.With(
-				prometheus.Labels{"type": final, "status": completed}).Set(finalCompleted)
-			migrationGauge.With(
-				prometheus.Labels{"type": final, "status": failed}).Set(finalFailed)
-		}
-	}()
-}
 
 // ReconcileMigMigration reconciles a MigMigration object
 type ReconcileMigMigration struct {


### PR DESCRIPTION
## Purpose
Instruments mig-controller with a prometheus metrics endpoint on http://localhost:2112/metrics. 

Initial implementation is intended to provide something to prove out the rest of the metrics plumbing with, and when eventually paired with Grafana dashboards will give us graphical insight on how migrations are progressing for mig-controller.

Cardinality = 8 for the `mig_migrations` metric I've added so far, which should be in bounds for the guidelines set by OpenShift.

## Preview of metrics available
```
# These metrics were pulled from a mig-controller instance where there was 
# just a single "final" MigMigration sitting idle, not yet in ready condition.

$ curl http://localhost:2112/metrics | grep mig_migration

# HELP mig_migrations Count of MigMigrations sorted by status and type
# TYPE mig_migrations gauge
mig_migrations{status="completed",type="final"} 0
mig_migrations{status="completed",type="stage"} 0
mig_migrations{status="error",type="final"} 0
mig_migrations{status="error",type="stage"} 0
mig_migrations{status="idle",type="final"} 1
mig_migrations{status="idle",type="stage"} 0
mig_migrations{status="running",type="final"} 0
mig_migrations{status="running",type="stage"} 0

```