### PR TITLE
When closing plan, only clean up ready clusters

### DIFF
--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -294,6 +294,9 @@ func (r *ReconcileMigPlan) ensureClosed(plan *migapi.MigPlan) error {
 		return err
 	}
 	for _, cluster := range clusters {
+		if !cluster.Status.IsReady() {
+			continue
+		}
 		err = cluster.DeleteResources(r, plan.GetCorrelationLabels())
 		if err != nil {
 			log.Trace(err)


### PR DESCRIPTION
Prior fix for https://bugzilla.redhat.com/show_bug.cgi?id=1758269 got reverted in a merge.