### PR TITLE
Adjust migration metric naming

### DIFF
--- a/pkg/controller/migmigration/metrics.go
+++ b/pkg/controller/migmigration/metrics.go
@@ -29,7 +29,7 @@ var (
 	// 'status' - [ idle, running, completed, error ]
 	// 'type'   - [ stage, final ]
 	migrationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mig_migrations_count",
+		Name: "cam_app_workload_migration_total",
 		Help: "Count of MigMigrations sorted by status and type",
 	},
 		[]string{"type", "status"},

--- a/pkg/controller/migmigration/metrics.go
+++ b/pkg/controller/migmigration/metrics.go
@@ -29,7 +29,7 @@ var (
 	// 'status' - [ idle, running, completed, error ]
 	// 'type'   - [ stage, final ]
 	migrationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mig_migrations",
+		Name: "mig_migrations_count",
 		Help: "Count of MigMigrations sorted by status and type",
 	},
 		[]string{"type", "status"},


### PR DESCRIPTION
Follow best practice of including unit on metrics per https://prometheus.io/docs/practices/naming/#metric-names