### PR TITLE
Support skipping TLS verification for S3 compatible storage

### DIFF
--- a/config/crds/migration_v1alpha1_migstorage.yaml
+++ b/config/crds/migration_v1alpha1_migstorage.yaml
@@ -54,13 +54,13 @@ spec:
                   type: object
                 gcpBucket:
                   type: string
-                insecureSkipTLSVerify:
+                insecure:
                   type: boolean
                 s3CustomCABundle:
                   format: byte
                   type: string
               required:
-              - insecureSkipTLSVerify
+              - insecure
               type: object
             backupStorageProvider:
               type: string

--- a/config/crds/migration_v1alpha1_migstorage.yaml
+++ b/config/crds/migration_v1alpha1_migstorage.yaml
@@ -54,9 +54,13 @@ spec:
                   type: object
                 gcpBucket:
                   type: string
+                insecureSkipTLSVerify:
+                  type: boolean
                 s3CustomCABundle:
                   format: byte
                   type: string
+              required:
+              - insecureSkipTLSVerify
               type: object
             backupStorageProvider:
               type: string

--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -92,7 +92,7 @@ type BackupStorageConfig struct {
 	AzureStorageContainer string                `json:"azureStorageContainer,omitempty"`
 	AzureResourceGroup    string                `json:"azureResourceGroup,omitempty"`
 	GcpBucket             string                `json:"gcpBucket,omitempty"`
-	InsecureSkipTLSVerify bool                  `json:"insecureSkipTLSVerify"`
+	Insecure              bool                  `json:"insecure"`
 }
 
 func init() {
@@ -224,15 +224,15 @@ func (r *BackupStorageConfig) GetProvider(name string) pvdr.Provider {
 				Role: pvdr.BackupStorage,
 				Name: name,
 			},
-			Region:                r.AwsRegion,
-			Bucket:                r.AwsBucketName,
-			S3URL:                 r.AwsS3URL,
-			PublicURL:             r.AwsPublicURL,
-			KMSKeyId:              r.AwsKmsKeyID,
-			SignatureVersion:      r.AwsSignatureVersion,
-			S3ForcePathStyle:      r.AwsS3ForcePathStyle,
-			CustomCABundle:        r.S3CustomCABundle,
-			InsecureSkipTLSVerify: r.InsecureSkipTLSVerify,
+			Region:           r.AwsRegion,
+			Bucket:           r.AwsBucketName,
+			S3URL:            r.AwsS3URL,
+			PublicURL:        r.AwsPublicURL,
+			KMSKeyId:         r.AwsKmsKeyID,
+			SignatureVersion: r.AwsSignatureVersion,
+			S3ForcePathStyle: r.AwsS3ForcePathStyle,
+			CustomCABundle:   r.S3CustomCABundle,
+			Insecure:         r.Insecure,
 		}
 	case Azure:
 		provider = &pvdr.AzureProvider{

--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -92,6 +92,7 @@ type BackupStorageConfig struct {
 	AzureStorageContainer string                `json:"azureStorageContainer,omitempty"`
 	AzureResourceGroup    string                `json:"azureResourceGroup,omitempty"`
 	GcpBucket             string                `json:"gcpBucket,omitempty"`
+	InsecureSkipTLSVerify bool                  `json:"insecureSkipTLSVerify"`
 }
 
 func init() {
@@ -223,14 +224,15 @@ func (r *BackupStorageConfig) GetProvider(name string) pvdr.Provider {
 				Role: pvdr.BackupStorage,
 				Name: name,
 			},
-			Region:           r.AwsRegion,
-			Bucket:           r.AwsBucketName,
-			S3URL:            r.AwsS3URL,
-			PublicURL:        r.AwsPublicURL,
-			KMSKeyId:         r.AwsKmsKeyID,
-			SignatureVersion: r.AwsSignatureVersion,
-			S3ForcePathStyle: r.AwsS3ForcePathStyle,
-			CustomCABundle:   r.S3CustomCABundle,
+			Region:                r.AwsRegion,
+			Bucket:                r.AwsBucketName,
+			S3URL:                 r.AwsS3URL,
+			PublicURL:             r.AwsPublicURL,
+			KMSKeyId:              r.AwsKmsKeyID,
+			SignatureVersion:      r.AwsSignatureVersion,
+			S3ForcePathStyle:      r.AwsS3ForcePathStyle,
+			CustomCABundle:        r.S3CustomCABundle,
+			InsecureSkipTLSVerify: r.InsecureSkipTLSVerify,
 		}
 	case Azure:
 		provider = &pvdr.AzureProvider{


### PR DESCRIPTION
Adds a field named 'insecureSkipTLSVerify' to the migstorage CRD, the value of which is passed to Velero through a field of the same name in the BSL config. This allows turning off TLS certificate verification for the purpose of supporting self-signed certificates.

This is part of the solution, together with fusor/restic#3 and fusor/velero#44