### PR TITLE
Revert "migcluster: use caBundle unless 'insecureSkipTLSVerify' is tr…

### DIFF
--- a/config/crds/migration_v1alpha1_migcluster.yaml
+++ b/config/crds/migration_v1alpha1_migcluster.yaml
@@ -33,8 +33,6 @@ spec:
             caBundle:
               format: byte
               type: string
-            insecureSkipTLSVerify:
-              type: boolean
             isHostCluster:
               type: boolean
             serviceAccountSecretRef:

--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -48,7 +48,6 @@ type MigClusterSpec struct {
 	CABundle                []byte                `json:"caBundle,omitempty"`
 	StorageClasses          []StorageClass        `json:"storageClasses,omitempty"`
 	AzureResourceGroup      string                `json:"azureResourceGroup,omitempty"`
-	InsecureSkipTLSVerify   bool                  `json:"insecureSkipTLSVerify"`
 }
 
 // MigClusterStatus defines the observed state of MigCluster
@@ -152,16 +151,12 @@ func (m *MigCluster) BuildRestConfig(c k8sclient.Client) (*rest.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	var tlsClientConfig rest.TLSClientConfig
-	if m.Spec.InsecureSkipTLSVerify {
-		tlsClientConfig = rest.TLSClientConfig{Insecure: true}
-	} else {
-		tlsClientConfig = rest.TLSClientConfig{Insecure: false, CAData: m.Spec.CABundle}
-	}
 	restConfig := &rest.Config{
-		Host:            m.Spec.URL,
-		BearerToken:     string(secret.Data[SaToken]),
-		TLSClientConfig: tlsClientConfig,
+		Host:        m.Spec.URL,
+		BearerToken: string(secret.Data[SaToken]),
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: true,
+		},
 	}
 
 	return restConfig, nil


### PR DESCRIPTION
…ue (#347)"

This reverts commit 4edebc389b992773934e3a54c117366d319431a8.

This wasn't meant to be included in 1.1. Reverting.