### PR TITLE
Fix REST API concurrency.

### DIFF
--- a/pkg/controller/discovery/web/ns.go
+++ b/pkg/controller/discovery/web/ns.go
@@ -14,12 +14,12 @@ const (
 // Namespaces (route) handler.
 type NsHandler struct {
 	// Base
-	ClusterHandler
+	ClusterScoped
 }
 
 //
 // Add routes.
-func (h *NsHandler) AddRoutes(r *gin.Engine) {
+func (h NsHandler) AddRoutes(r *gin.Engine) {
 	r.GET(NamespacesRoot, h.List)
 	r.GET(NamespacesRoot+"/", h.List)
 	r.GET(NamespaceRoot, h.Get)
@@ -27,7 +27,7 @@ func (h *NsHandler) AddRoutes(r *gin.Engine) {
 
 //
 // List namespaces on a cluster.
-func (h *NsHandler) List(ctx *gin.Context) {
+func (h NsHandler) List(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
 		h.ctx.Status(status)
@@ -39,7 +39,7 @@ func (h *NsHandler) List(ctx *gin.Context) {
 		h.ctx.Status(http.StatusInternalServerError)
 		return
 	}
-	content := []string{}
+	content := []Namespace{}
 	for _, m := range list {
 		content = append(content, m.Name)
 	}
@@ -49,7 +49,7 @@ func (h *NsHandler) List(ctx *gin.Context) {
 
 //
 // Get a specific namespace on a cluster.
-func (h *NsHandler) Get(ctx *gin.Context) {
+func (h NsHandler) Get(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
 		h.ctx.Status(status)
@@ -58,3 +58,6 @@ func (h *NsHandler) Get(ctx *gin.Context) {
 
 	h.ctx.JSON(http.StatusOK, h.cluster.Namespace)
 }
+
+// Namespace REST resource
+type Namespace = string

--- a/pkg/controller/discovery/web/pod.go
+++ b/pkg/controller/discovery/web/pod.go
@@ -25,12 +25,12 @@ const (
 // Pod (route) handler.
 type PodHandler struct {
 	// Base
-	ClusterHandler
+	ClusterScoped
 }
 
 //
 // Add routes.
-func (h *PodHandler) AddRoutes(r *gin.Engine) {
+func (h PodHandler) AddRoutes(r *gin.Engine) {
 	r.GET(PodsRoot, h.List)
 	r.GET(PodsRoot+"/", h.List)
 	r.GET(PodRoot, h.Get)
@@ -38,7 +38,7 @@ func (h *PodHandler) AddRoutes(r *gin.Engine) {
 
 //
 // Get a specific pod.
-func (h *PodHandler) Get(ctx *gin.Context) {
+func (h PodHandler) Get(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
 		h.ctx.Status(status)
@@ -75,7 +75,7 @@ func (h *PodHandler) Get(ctx *gin.Context) {
 
 //
 // List pods on a cluster in a namespace.
-func (h *PodHandler) List(ctx *gin.Context) {
+func (h PodHandler) List(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
 		h.ctx.Status(status)
@@ -113,17 +113,23 @@ func (h *PodHandler) List(ctx *gin.Context) {
 // Pod-log (route) handler.
 type LogHandler struct {
 	// Base
-	ClusterHandler
+	ClusterScoped
 }
 
 // Add routes.
-func (h *LogHandler) AddRoutes(r *gin.Engine) {
+func (h LogHandler) AddRoutes(r *gin.Engine) {
 	r.GET(PodRoot+"/log", h.List)
 }
 
 //
+// Not supported.
+func (h LogHandler) Get(ctx *gin.Context) {
+	ctx.Status(http.StatusMethodNotAllowed)
+}
+
+//
 // List all logs (entries) for a pod (and optional container).
-func (h *LogHandler) List(ctx *gin.Context) {
+func (h LogHandler) List(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
 		h.ctx.Status(status)


### PR DESCRIPTION
Fixes concurrency issue: #395 
The `RequestHandler` is stateful.  Therofore, the handling methods cannot have a pointer _receiver_ so that the receiver is passed by-value and the struct is copied for each request. I updated the `RequestHandler` interface and added `List` and `Get` to formalize (and enforce) this concept. The handlers needed some minor refactoring to comply.

The diff looks like more than it is because some methods just got moved (within the struct) for consistent ordering.