### PR TITLE
Fix race condition in DataSource startup.

### DIFF
--- a/pkg/controller/discovery/container/pod.go
+++ b/pkg/controller/discovery/container/pod.go
@@ -44,8 +44,10 @@ func (r *PodCollection) Reconcile() error {
 	r.hasReconciled = true
 	Log.Info(
 		"PodCollection reconciled.",
-		"cluster",
-		r.ds.cluster,
+		"ns",
+		r.ds.Cluster.Namespace,
+		"name",
+		r.ds.Cluster.Name,
 		"duration",
 		time.Since(mark))
 
@@ -55,7 +57,7 @@ func (r *PodCollection) Reconcile() error {
 func (r *PodCollection) GetDiscovered() ([]model.Model, error) {
 	models := []model.Model{}
 	onCluster := v1.PodList{}
-	err := r.ds.client.List(context.TODO(), nil, &onCluster)
+	err := r.ds.Client.List(context.TODO(), nil, &onCluster)
 	if err != nil {
 		Log.Trace(err)
 		return nil, err
@@ -63,7 +65,7 @@ func (r *PodCollection) GetDiscovered() ([]model.Model, error) {
 	for _, discovered := range onCluster.Items {
 		ns := &model.Pod{
 			Base: model.Base{
-				Cluster: r.ds.cluster.PK,
+				Cluster: r.ds.Cluster.PK,
 			},
 		}
 		ns.With(&discovered)
@@ -75,7 +77,7 @@ func (r *PodCollection) GetDiscovered() ([]model.Model, error) {
 
 func (r *PodCollection) GetStored() ([]model.Model, error) {
 	models := []model.Model{}
-	list, err := r.ds.cluster.PodList(r.ds.Container.Db, nil)
+	list, err := r.ds.Cluster.PodList(r.ds.Container.Db, nil)
 	if err != nil {
 		Log.Trace(err)
 		return nil, err
@@ -99,14 +101,11 @@ func (r *PodCollection) Create(e event.CreateEvent) bool {
 	}
 	pod := model.Pod{
 		Base: model.Base{
-			Cluster: r.ds.cluster.PK,
+			Cluster: r.ds.Cluster.PK,
 		},
 	}
 	pod.With(object)
-	err := pod.Insert(r.ds.Container.Db)
-	if err != nil {
-		Log.Trace(err)
-	}
+	r.ds.Create(&pod)
 
 	return false
 }
@@ -119,14 +118,11 @@ func (r *PodCollection) Update(e event.UpdateEvent) bool {
 	}
 	pod := model.Pod{
 		Base: model.Base{
-			Cluster: r.ds.cluster.PK,
+			Cluster: r.ds.Cluster.PK,
 		},
 	}
 	pod.With(object)
-	err := pod.Update(r.ds.Container.Db)
-	if err != nil {
-		Log.Trace(err)
-	}
+	r.ds.Update(&pod)
 
 	return false
 }
@@ -139,14 +135,11 @@ func (r *PodCollection) Delete(e event.DeleteEvent) bool {
 	}
 	pod := model.Pod{
 		Base: model.Base{
-			Cluster: r.ds.cluster.PK,
+			Cluster: r.ds.Cluster.PK,
 		},
 	}
 	pod.With(object)
-	err := pod.Delete(r.ds.Container.Db)
-	if err != nil {
-		Log.Trace(err)
-	}
+	r.ds.Delete(&pod)
 
 	return false
 }

--- a/pkg/controller/discovery/container/pv.go
+++ b/pkg/controller/discovery/container/pv.go
@@ -45,8 +45,10 @@ func (r *PvCollection) Reconcile() error {
 	r.hasReconciled = true
 	Log.Info(
 		"PvCollection reconciled.",
-		"cluster",
-		r.ds.cluster,
+		"ns",
+		r.ds.Cluster.Namespace,
+		"name",
+		r.ds.Cluster.Name,
 		"duration",
 		time.Since(mark))
 
@@ -56,7 +58,7 @@ func (r *PvCollection) Reconcile() error {
 func (r *PvCollection) GetDiscovered() ([]model.Model, error) {
 	models := []model.Model{}
 	onCluster := v1.PersistentVolumeList{}
-	err := r.ds.client.List(context.TODO(), nil, &onCluster)
+	err := r.ds.Client.List(context.TODO(), nil, &onCluster)
 	if err != nil {
 		Log.Trace(err)
 		return nil, err
@@ -64,7 +66,7 @@ func (r *PvCollection) GetDiscovered() ([]model.Model, error) {
 	for _, discovered := range onCluster.Items {
 		pv := &model.PV{
 			Base: model.Base{
-				Cluster: r.ds.cluster.PK,
+				Cluster: r.ds.Cluster.PK,
 			},
 		}
 		pv.With(&discovered)
@@ -76,7 +78,7 @@ func (r *PvCollection) GetDiscovered() ([]model.Model, error) {
 
 func (r *PvCollection) GetStored() ([]model.Model, error) {
 	models := []model.Model{}
-	list, err := r.ds.cluster.PvList(r.ds.Container.Db, nil)
+	list, err := r.ds.Cluster.PvList(r.ds.Container.Db, nil)
 	if err != nil {
 		Log.Trace(err)
 		return nil, err
@@ -100,14 +102,11 @@ func (r *PvCollection) Create(e event.CreateEvent) bool {
 	}
 	pv := model.PV{
 		Base: model.Base{
-			Cluster: r.ds.cluster.PK,
+			Cluster: r.ds.Cluster.PK,
 		},
 	}
 	pv.With(object)
-	err := pv.Insert(r.ds.Container.Db)
-	if err != nil {
-		Log.Trace(err)
-	}
+	r.ds.Create(&pv)
 
 	return false
 }
@@ -120,14 +119,11 @@ func (r *PvCollection) Update(e event.UpdateEvent) bool {
 	}
 	pv := model.PV{
 		Base: model.Base{
-			Cluster: r.ds.cluster.PK,
+			Cluster: r.ds.Cluster.PK,
 		},
 	}
 	pv.With(object)
-	err := pv.Update(r.ds.Container.Db)
-	if err != nil {
-		Log.Trace(err)
-	}
+	r.ds.Update(&pv)
 
 	return false
 }
@@ -140,14 +136,11 @@ func (r *PvCollection) Delete(e event.DeleteEvent) bool {
 	}
 	pv := model.PV{
 		Base: model.Base{
-			Cluster: r.ds.cluster.PK,
+			Cluster: r.ds.Cluster.PK,
 		},
 	}
 	pv.With(object)
-	err := pv.Delete(r.ds.Container.Db)
-	if err != nil {
-		Log.Trace(err)
-	}
+	r.ds.Delete(&pv)
 
 	return false
 }

--- a/pkg/controller/discovery/controller.go
+++ b/pkg/controller/discovery/controller.go
@@ -70,7 +70,8 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	options := controller.Options{
-		Reconciler: r,
+		MaxConcurrentReconciles: 10,
+		Reconciler:              r,
 	}
 	c, err := controller.New("discovery", mgr, options)
 	if err != nil {

--- a/pkg/controller/discovery/model/model.go
+++ b/pkg/controller/discovery/model/model.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	pathlib "path"
 	"reflect"
+	"strconv"
 )
 
 // Shared logger.
@@ -155,6 +156,17 @@ func (m *Base) SetPk() {
 // Get base.
 func (m *Base) GetBase() *Base {
 	return m
+}
+
+// Get `version` as a unit64.
+// Returns `0` on parse error.
+func (m *Base) IntVersion() uint64 {
+	version, err := strconv.ParseUint(m.GetBase().Version, 10, 64)
+	if err != nil {
+		Log.Trace(err)
+		return 0
+	}
+	return version
 }
 
 //

--- a/pkg/controller/migmigration/metrics.go
+++ b/pkg/controller/migmigration/metrics.go
@@ -29,7 +29,7 @@ var (
 	// 'status' - [ idle, running, completed, error ]
 	// 'type'   - [ stage, final ]
 	migrationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "cam_app_workload_migration_total",
+		Name: "mig_migrations",
 		Help: "Count of MigMigrations sorted by status and type",
 	},
 		[]string{"type", "status"},


### PR DESCRIPTION
Fixes: https://github.com/fusor/mig-controller/issues/400

The `DataSource` startup is designed to provide a baseline snapshot which is then updated with incremental changes based on _watch_.  The initial snapshot ensures a minimum sane result for REST requests processed immediately after startup or a `MigCluster` is added.

The steps had been:
1. Full Reconcile()
2. Start remote watches.

However, the time between 1 & 2 provided window in which resource add/update/delete would be missed because watches had not yet been setup.

This PR changes the steps to:
1. Start remote watches (events are queued).
2. Full Reconcile()
3. Begin processing queued watch events.

The overlap is safe because the Primary Key for an object stored in DB includes the k8s UID. 
An insert has no affect when the object already exists.
A delete of an object that does not exist has no affect.
Object updates will be applied in order and last update wins.