### PR TITLE
Fixes to edge-case issues.

### DIFF
--- a/pkg/controller/discovery/container/collection.go
+++ b/pkg/controller/discovery/container/collection.go
@@ -75,7 +75,6 @@ func (r *BaseCollection) IsReady() bool {
 // Reset `hasReconciled` and association with a DataSource.
 func (r *BaseCollection) Reset() {
 	r.hasReconciled = false
-	r.ds = nil
 }
 
 //
@@ -132,6 +131,8 @@ func (r *SimpleReconciler) Reconcile(collection Collection) error {
 			dpn.discovered = m
 		}
 	}
+	model.Mutex.RLock()
+	defer model.Mutex.RUnlock()
 	tx, err := r.Db.Begin()
 	if err != nil {
 		Log.Trace(err)

--- a/pkg/controller/discovery/container/ds.go
+++ b/pkg/controller/discovery/container/ds.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	migapi "github.com/fusor/mig-controller/pkg/apis/migration/v1alpha1"
 	"github.com/fusor/mig-controller/pkg/controller/discovery/model"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -209,7 +210,11 @@ func (r *DataSource) buildClient(cluster *migapi.MigCluster) error {
 		Log.Trace(err)
 		return err
 	}
-	r.Client, err = cluster.GetClient(r.Container.Client)
+	r.Client, err = client.New(
+		r.RestCfg,
+		client.Options{
+			Scheme: scheme.Scheme,
+		})
 	if err != nil {
 		Log.Trace(err)
 		return err

--- a/pkg/controller/discovery/controller.go
+++ b/pkg/controller/discovery/controller.go
@@ -36,19 +36,23 @@ import (
 	"time"
 )
 
-var log = logging.WithName("discovery")
+var log logging.Logger
 
 // Application settings.
 var Settings = &settings.Settings
+
+func init() {
+	log = logging.WithName("discovery")
+	model.Log = &log
+	container.Log = &log
+	web.Log = &log
+}
 
 func Add(mgr manager.Manager) error {
 	return add(mgr, newReconciler(mgr))
 }
 
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	model.Log = &log
-	container.Log = &log
-	web.Log = &log
 	db, err := model.Create()
 	if err != nil {
 		panic(err)

--- a/pkg/controller/discovery/model/cluster.go
+++ b/pkg/controller/discovery/model/cluster.go
@@ -170,6 +170,8 @@ func (m *Cluster) Select(db DB) error {
 // Update on duplicate key.
 func (m *Cluster) Insert(db DB) error {
 	m.SetPk()
+	Mutex.RLock()
+	defer Mutex.RUnlock()
 	r, err := db.Exec(
 		ClusterInsertSQL,
 		sql.Named("pk", m.PK),
@@ -203,6 +205,8 @@ func (m *Cluster) Insert(db DB) error {
 // Update the model in the DB.
 func (m *Cluster) Update(db DB) error {
 	m.SetPk()
+	Mutex.RLock()
+	defer Mutex.RUnlock()
 	r, err := db.Exec(
 		ClusterUpdateSQL,
 		sql.Named("pk", m.PK),
@@ -228,6 +232,8 @@ func (m *Cluster) Update(db DB) error {
 // Delete the model in the DB.
 func (m *Cluster) Delete(db DB) error {
 	m.SetPk()
+	Mutex.RLock()
+	defer Mutex.RUnlock()
 	r, err := db.Exec(
 		ClusterDeleteSQL,
 		sql.Named("namespace", m.Namespace),
@@ -278,6 +284,7 @@ func (m *Cluster) NsList(db DB, page *Page) ([]*Namespace, error) {
 			&ns.Cluster)
 		if err != nil {
 			Log.Trace(err)
+			return nil, err
 		}
 		list = append(list, &ns)
 	}
@@ -316,6 +323,7 @@ func (m *Cluster) PvList(db DB, page *Page) ([]*PV, error) {
 			&pv.Cluster)
 		if err != nil {
 			Log.Trace(err)
+			return nil, err
 		}
 		list = append(list, &pv)
 	}
@@ -355,6 +363,7 @@ func (m *Cluster) PodList(db DB, page *Page) ([]*Pod, error) {
 			&pod.Cluster)
 		if err != nil {
 			Log.Trace(err)
+			return nil, err
 		}
 		list = append(list, &pod)
 	}
@@ -395,6 +404,7 @@ func (m *Cluster) PodListByLabel(db DB, labels LabelFilter, page *Page) ([]*Pod,
 			&pod.Cluster)
 		if err != nil {
 			Log.Trace(err)
+			return nil, err
 		}
 		list = append(list, &pod)
 	}
@@ -432,6 +442,7 @@ func ClusterList(db DB, page *Page) ([]Cluster, error) {
 			&cluster.Secret)
 		if err != nil {
 			Log.Trace(err)
+			return nil, err
 		}
 		list = append(list, cluster)
 	}

--- a/pkg/controller/discovery/model/ns.go
+++ b/pkg/controller/discovery/model/ns.go
@@ -83,6 +83,8 @@ func (m *Namespace) With(object *v1.Namespace) {
 // Insert the model into the DB.
 func (m *Namespace) Insert(db DB) error {
 	m.SetPk()
+	Mutex.RLock()
+	defer Mutex.RUnlock()
 	r, err := db.Exec(
 		NsInsertSQL,
 		sql.Named("pk", m.PK),
@@ -121,6 +123,8 @@ func (m *Namespace) Update(db DB) error {
 // Delete the model in the DB.
 func (m *Namespace) Delete(db DB) error {
 	m.SetPk()
+	Mutex.RLock()
+	defer Mutex.RUnlock()
 	r, err := db.Exec(NsDeleteSQL, sql.Named("pk", m.PK))
 	if err != nil {
 		Log.Trace(err)

--- a/pkg/controller/discovery/model/plan.go
+++ b/pkg/controller/discovery/model/plan.go
@@ -177,6 +177,8 @@ func (m *Plan) Select(db DB) error {
 // Update on duplicate key.
 func (m *Plan) Insert(db DB) error {
 	m.SetPk()
+	Mutex.RLock()
+	defer Mutex.RUnlock()
 	r, err := db.Exec(
 		PlanInsertSQL,
 		sql.Named("pk", m.PK),
@@ -211,6 +213,8 @@ func (m *Plan) Insert(db DB) error {
 // Update the model in the DB.
 func (m *Plan) Update(db DB) error {
 	m.SetPk()
+	Mutex.RLock()
+	defer Mutex.RUnlock()
 	r, err := db.Exec(
 		PlanUpdateSQL,
 		sql.Named("pk", m.PK),
@@ -237,6 +241,8 @@ func (m *Plan) Update(db DB) error {
 // Delete the model in the DB.
 func (m *Plan) Delete(db DB) error {
 	m.SetPk()
+	Mutex.RLock()
+	defer Mutex.RUnlock()
 	r, err := db.Exec(PlanDeleteSQL, sql.Named("pk", m.PK))
 	if err != nil {
 		Log.Trace(err)

--- a/pkg/controller/discovery/model/pod.go
+++ b/pkg/controller/discovery/model/pod.go
@@ -279,6 +279,8 @@ func (m *Pod) Select(db DB) error {
 // Update on duplicate key.
 func (m *Pod) Insert(db DB) error {
 	m.SetPk()
+	Mutex.RLock()
+	defer Mutex.RUnlock()
 	r, err := db.Exec(
 		PodInsertSQL,
 		sql.Named("pk", m.PK),
@@ -324,6 +326,8 @@ func (m *Pod) Insert(db DB) error {
 // Update the model in the DB.
 func (m *Pod) Update(db DB) error {
 	m.SetPk()
+	Mutex.RLock()
+	defer Mutex.RUnlock()
 	r, err := db.Exec(
 		PodUpdateSQL,
 		sql.Named("version", m.Version),
@@ -354,6 +358,8 @@ func (m *Pod) Update(db DB) error {
 // Delete the model in the DB.
 func (m *Pod) Delete(db DB) error {
 	m.SetPk()
+	Mutex.RLock()
+	defer Mutex.RUnlock()
 	r, err := db.Exec(PodDeleteSQL, sql.Named("pk", m.PK))
 	if err != nil {
 		Log.Trace(err)

--- a/pkg/controller/discovery/model/pv.go
+++ b/pkg/controller/discovery/model/pv.go
@@ -148,6 +148,8 @@ func (m *PV) Select(db DB) error {
 // Update on duplicate key.
 func (m *PV) Insert(db DB) error {
 	m.SetPk()
+	Mutex.RLock()
+	defer Mutex.RUnlock()
 	r, err := db.Exec(
 		PvInsertSQL,
 		sql.Named("pk", m.PK),
@@ -181,6 +183,8 @@ func (m *PV) Insert(db DB) error {
 // Update the model in the DB.
 func (m *PV) Update(db DB) error {
 	m.SetPk()
+	Mutex.RLock()
+	defer Mutex.RUnlock()
 	r, err := db.Exec(
 		PvUpdateSQL,
 		sql.Named("version", m.Version),
@@ -206,6 +210,8 @@ func (m *PV) Update(db DB) error {
 // Delete the model in the DB.
 func (m *PV) Delete(db DB) error {
 	m.SetPk()
+	Mutex.RLock()
+	defer Mutex.RUnlock()
 	r, err := db.Exec(PvDeleteSQL, sql.Named("pk", m.PK))
 	if err != nil {
 		Log.Trace(err)


### PR DESCRIPTION
Few important fixes needed in case more than 1 MigCluster references the `host`.

---

The logger is global and needed a mutex to protect the `history`.

The sqlite3 DB driver does not support concurrent writes.  Added mutex and used appropriately.