### PR TITLE
Change metric name accounting for Gauge type

### DIFF
--- a/pkg/controller/migmigration/metrics.go
+++ b/pkg/controller/migmigration/metrics.go
@@ -29,7 +29,7 @@ var (
 	// 'status' - [ idle, running, completed, error ]
 	// 'type'   - [ stage, final ]
 	migrationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mig_migrations",
+		Name: "cam_app_workload_migrations",
 		Help: "Count of MigMigrations sorted by status and type",
 	},
 		[]string{"type", "status"},


### PR DESCRIPTION
Lili Cosic from the monitoring team requested that we remove "total" from our metric name since we are exporting a gauge, not a counter. 

Sidenote: the original change to this metric name was accidentally overwritten in some discovery service optimizations: https://github.com/fusor/mig-controller/commit/96d3cbc2ee69efc44807d0750b06a2405fed53f2#diff-7c2ce421de3d2494470eca20bd12e5a8