### PR TITLE
Replace the Touch ID with observedGeneration.

### DIFF
--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -53,6 +53,7 @@ type MigClusterSpec struct {
 // MigClusterStatus defines the observed state of MigCluster
 type MigClusterStatus struct {
 	Conditions
+	ObservedGeneration int64 `json:"observedGeneration"`
 }
 
 // +genclient

--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -40,9 +40,10 @@ type MigMigrationSpec struct {
 type MigMigrationStatus struct {
 	Conditions
 	UnhealthyResources
-	StartTimestamp *metav1.Time `json:"startTimestamp,omitempty"`
-	Phase          string       `json:"phase,omitempty"`
-	Errors         []string     `json:"errors,omitempty"`
+	ObservedGeneration int64        `json:"observedGeneration"`
+	StartTimestamp     *metav1.Time `json:"startTimestamp,omitempty"`
+	Phase              string       `json:"phase,omitempty"`
+	Errors             []string     `json:"errors,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -57,6 +57,7 @@ type MigPlanSpec struct {
 // MigPlanStatus defines the observed state of MigPlan
 type MigPlanStatus struct {
 	Conditions
+	ObservedGeneration int64 `json:"observedGeneration"`
 }
 
 // +genclient

--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -44,6 +44,7 @@ type MigStorageSpec struct {
 // MigStorageStatus defines the observed state of MigStorage
 type MigStorageStatus struct {
 	Conditions
+	ObservedGeneration int64 `json:"observedGeneration"`
 }
 
 // +genclient

--- a/pkg/apis/migration/v1alpha1/resource.go
+++ b/pkg/apis/migration/v1alpha1/resource.go
@@ -1,19 +1,10 @@
 package v1alpha1
 
-import (
-	"github.com/google/uuid"
-)
-
 const (
-	TouchAnnotation = "touch"
 	VeleroNamespace = "openshift-migration"
 )
 
 // Migration application CR.
-// The `touch` UUID is set by the controller after reconcile
-// and needed to support relay of remote watch events. Also to
-// provide remote watch predicates the ability to determine
-// when an updated referenced resource has been fully reconciled.
 type MigResource interface {
 	// Get a map containing the correlation label.
 	GetCorrelationLabels() map[string]string
@@ -23,10 +14,10 @@ type MigResource interface {
 	GetNamespace() string
 	// Get the resource name.
 	GetName() string
-	// Get the `touch` UUID annotation.
-	GetTouch() string
-	// Set the `touch` UUID annotation.
-	Touch()
+	// Mark the resource as having been reconciled.
+	MarkReconciled()
+	// Get whether the resource has been reconciled.
+	HasReconciled() bool
 }
 
 // Plan
@@ -50,23 +41,12 @@ func (r *MigPlan) GetName() string {
 	return r.Name
 }
 
-func (r *MigPlan) GetTouch() string {
-	if r.Annotations == nil {
-		return ""
-	}
-	id, found := r.Annotations[TouchAnnotation]
-	if found {
-		return id
-	}
-
-	return ""
+func (r *MigPlan) MarkReconciled() {
+	r.Status.ObservedGeneration = r.Generation + 1
 }
 
-func (r *MigPlan) Touch() {
-	if r.Annotations == nil {
-		r.Annotations = make(map[string]string)
-	}
-	r.Annotations[TouchAnnotation] = uuid.New().String()
+func (r *MigPlan) HasReconciled() bool {
+	return r.Status.ObservedGeneration == r.Generation
 }
 
 // Storage
@@ -90,23 +70,12 @@ func (r *MigStorage) GetName() string {
 	return r.Name
 }
 
-func (r *MigStorage) GetTouch() string {
-	if r.Annotations == nil {
-		return ""
-	}
-	id, found := r.Annotations[TouchAnnotation]
-	if found {
-		return id
-	}
-
-	return ""
+func (r *MigStorage) MarkReconciled() {
+	r.Status.ObservedGeneration = r.Generation + 1
 }
 
-func (r *MigStorage) Touch() {
-	if r.Annotations == nil {
-		r.Annotations = make(map[string]string)
-	}
-	r.Annotations[TouchAnnotation] = uuid.New().String()
+func (r *MigStorage) HasReconciled() bool {
+	return r.Status.ObservedGeneration == r.Generation
 }
 
 // Cluster
@@ -130,23 +99,12 @@ func (r *MigCluster) GetName() string {
 	return r.Name
 }
 
-func (r *MigCluster) GetTouch() string {
-	if r.Annotations == nil {
-		return ""
-	}
-	id, found := r.Annotations[TouchAnnotation]
-	if found {
-		return id
-	}
-
-	return ""
+func (r *MigCluster) MarkReconciled() {
+	r.Status.ObservedGeneration = r.Generation + 1
 }
 
-func (r *MigCluster) Touch() {
-	if r.Annotations == nil {
-		r.Annotations = make(map[string]string)
-	}
-	r.Annotations[TouchAnnotation] = uuid.New().String()
+func (r *MigCluster) HasReconciled() bool {
+	return r.Status.ObservedGeneration == r.Generation
 }
 
 // Migration
@@ -170,21 +128,10 @@ func (r *MigMigration) GetName() string {
 	return r.Name
 }
 
-func (r *MigMigration) GetTouch() string {
-	if r.Annotations == nil {
-		return ""
-	}
-	id, found := r.Annotations[TouchAnnotation]
-	if found {
-		return id
-	}
-
-	return ""
+func (r *MigMigration) MarkReconciled() {
+	r.Status.ObservedGeneration = r.Generation + 1
 }
 
-func (r *MigMigration) Touch() {
-	if r.Annotations == nil {
-		r.Annotations = make(map[string]string)
-	}
-	r.Annotations[TouchAnnotation] = uuid.New().String()
+func (r *MigMigration) HasReconciled() bool {
+	return r.Status.ObservedGeneration == r.Generation
 }

--- a/pkg/controller/migcluster/migcluster_controller.go
+++ b/pkg/controller/migcluster/migcluster_controller.go
@@ -177,7 +177,7 @@ func (r *ReconcileMigCluster) Reconcile(request reconcile.Request) (reconcile.Re
 	cluster.Status.EndStagingConditions()
 
 	// Apply changes.
-	cluster.Touch()
+	cluster.MarkReconciled()
 	err = r.Update(context.TODO(), cluster)
 	if err != nil {
 		log.Trace(err)

--- a/pkg/controller/migmigration/migmigration_controller.go
+++ b/pkg/controller/migmigration/migmigration_controller.go
@@ -209,7 +209,7 @@ func (r *ReconcileMigMigration) Reconcile(request reconcile.Request) (reconcile.
 	migration.Status.EndStagingConditions()
 
 	// Apply changes.
-	migration.Touch()
+	migration.MarkReconciled()
 	err = r.Update(context.TODO(), migration)
 	if err != nil {
 		log.Trace(err)

--- a/pkg/controller/migmigration/predicate.go
+++ b/pkg/controller/migmigration/predicate.go
@@ -96,15 +96,10 @@ func (r PlanPredicate) Create(e event.CreateEvent) bool {
 }
 
 func (r PlanPredicate) Update(e event.UpdateEvent) bool {
-	old, cast := e.ObjectOld.(*migapi.MigPlan)
-	if !cast {
-		return false
-	}
 	new, cast := e.ObjectNew.(*migapi.MigPlan)
 	if !cast {
 		return false
 	}
-	// Updated by the controller.
-	touched := old.GetTouch() != new.GetTouch()
-	return touched
+	// Reconciled by the controller.
+	return new.HasReconciled()
 }

--- a/pkg/controller/migplan/migplan_controller.go
+++ b/pkg/controller/migplan/migplan_controller.go
@@ -256,7 +256,7 @@ func (r *ReconcileMigPlan) Reconcile(request reconcile.Request) (reconcile.Resul
 	plan.Status.EndStagingConditions()
 
 	// Apply changes.
-	plan.Touch()
+	plan.MarkReconciled()
 	err = r.Update(context.TODO(), plan)
 	if err != nil {
 		log.Trace(err)
@@ -275,7 +275,7 @@ func (r *ReconcileMigPlan) handleClosed(plan *migapi.MigPlan) (bool, error) {
 		return closed, nil
 	}
 
-	plan.Touch()
+	plan.MarkReconciled()
 	plan.Status.SetReady(false, ReadyMessage)
 	err := r.Update(context.TODO(), plan)
 	if err != nil {
@@ -311,7 +311,7 @@ func (r *ReconcileMigPlan) ensureClosed(plan *migapi.MigPlan) error {
 		Message:  ClosedMessage,
 	})
 	// Apply changes.
-	plan.Touch()
+	plan.MarkReconciled()
 	err = r.Update(context.TODO(), plan)
 	if err != nil {
 		log.Trace(err)

--- a/pkg/controller/migplan/predicate.go
+++ b/pkg/controller/migplan/predicate.go
@@ -136,17 +136,12 @@ func (r ClusterPredicate) Create(e event.CreateEvent) bool {
 }
 
 func (r ClusterPredicate) Update(e event.UpdateEvent) bool {
-	old, cast := e.ObjectOld.(*migapi.MigCluster)
-	if !cast {
-		return false
-	}
 	new, cast := e.ObjectNew.(*migapi.MigCluster)
 	if !cast {
 		return false
 	}
-	// Updated by the controller.
-	touched := old.GetTouch() != new.GetTouch()
-	return touched
+	// Reconciled by the controller.
+	return new.HasReconciled()
 }
 
 type StoragePredicate struct {
@@ -158,17 +153,12 @@ func (r StoragePredicate) Create(e event.CreateEvent) bool {
 }
 
 func (r StoragePredicate) Update(e event.UpdateEvent) bool {
-	old, cast := e.ObjectOld.(*migapi.MigStorage)
-	if !cast {
-		return false
-	}
 	new, cast := e.ObjectNew.(*migapi.MigStorage)
 	if !cast {
 		return false
 	}
-	// Updated by the controller.
-	touched := old.GetTouch() != new.GetTouch()
-	return touched
+	// Reconciled by the controller.
+	return new.HasReconciled()
 }
 
 type MigrationPredicate struct {

--- a/pkg/controller/migstorage/migstorage_controller.go
+++ b/pkg/controller/migstorage/migstorage_controller.go
@@ -150,7 +150,7 @@ func (r *ReconcileMigStorage) Reconcile(request reconcile.Request) (reconcile.Re
 	storage.Status.EndStagingConditions()
 
 	// Apply changes.
-	storage.Touch()
+	storage.MarkReconciled()
 	err = r.Update(context.TODO(), storage)
 	if err != nil {
 		log.Trace(err)


### PR DESCRIPTION
closes #401

Replaces the `touch` annotation with `Status.ObservedGeneration`.

The Touch ID provided:
- Ensured that the `resourceVersion` and `generation` were incremented (when updated) on OCP4 even when the resource (spec or status) did not change. This was essential for watch event propagation.
- Provided a means by which watch predicates (for referenced MIG resources) could ignore update events for un-reconciled resources.

The `observedGeneration` design pattern is used by _Kubernetes_ controllers (such as DaemonSet controller) and provides more information. The `observedGeneration` indicates the last generation reconciled by the controller. This provides a means to determine if a specific generation of interest has been reconciled. When reconciles are _caught up_ to resource updates, the `ObservedGeneration` will equal the `Generation`.