### PR TITLE
migcluster: use the CABundle unless 'insecure' is true

### DIFF
--- a/config/crds/migration_v1alpha1_migcluster.yaml
+++ b/config/crds/migration_v1alpha1_migcluster.yaml
@@ -33,6 +33,8 @@ spec:
             caBundle:
               format: byte
               type: string
+            insecure:
+              type: boolean
             isHostCluster:
               type: boolean
             serviceAccountSecretRef:

--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -48,6 +48,7 @@ type MigClusterSpec struct {
 	CABundle                []byte                `json:"caBundle,omitempty"`
 	StorageClasses          []StorageClass        `json:"storageClasses,omitempty"`
 	AzureResourceGroup      string                `json:"azureResourceGroup,omitempty"`
+	Insecure                bool                  `json:"insecure"`
 }
 
 // MigClusterStatus defines the observed state of MigCluster
@@ -152,12 +153,16 @@ func (m *MigCluster) BuildRestConfig(c k8sclient.Client) (*rest.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	var tlsClientConfig rest.TLSClientConfig
+	if m.Spec.Insecure {
+		tlsClientConfig = rest.TLSClientConfig{Insecure: true}
+	} else {
+		tlsClientConfig = rest.TLSClientConfig{Insecure: false, CAData: m.Spec.CABundle}
+	}
 	restConfig := &rest.Config{
-		Host:        m.Spec.URL,
-		BearerToken: string(secret.Data[SaToken]),
-		TLSClientConfig: rest.TLSClientConfig{
-			Insecure: true,
-		},
+		Host:            m.Spec.URL,
+		BearerToken:     string(secret.Data[SaToken]),
+		TLSClientConfig: tlsClientConfig,
 	}
 
 	return restConfig, nil


### PR DESCRIPTION
This is the PR (with a minor naming change) that was reverted in https://github.com/fusor/mig-controller/pull/396 because it had been mistakenly merged in for 1.1. Needed for MigCluster CA bundle support in 1.2.