### PR TITLE
Discovery minor tech debt.

### DIFF
--- a/pkg/controller/discovery/web/cluster.go
+++ b/pkg/controller/discovery/web/cluster.go
@@ -35,7 +35,7 @@ func (h *ClusterScoped) Prepare(ctx *gin.Context) int {
 	}
 	h.cluster = model.Cluster{
 		Base: model.Base{
-			Namespace: h.ctx.Param("namespace"),
+			Namespace: h.ctx.Param("ns1"),
 			Name:      h.ctx.Param("cluster"),
 		},
 	}

--- a/pkg/controller/discovery/web/cluster.go
+++ b/pkg/controller/discovery/web/cluster.go
@@ -35,8 +35,8 @@ func (h *ClusterScoped) Prepare(ctx *gin.Context) int {
 	}
 	h.cluster = model.Cluster{
 		Base: model.Base{
-			Namespace: h.ctx.Param("ns1"),
-			Name:      h.ctx.Param("cluster"),
+			Namespace: ctx.Param("ns1"),
+			Name:      ctx.Param("cluster"),
 		},
 	}
 	status = h.dsReady()
@@ -136,7 +136,7 @@ func (h ClusterHandler) AddRoutes(r *gin.Engine) {
 func (h ClusterHandler) List(ctx *gin.Context) {
 	status := h.BaseHandler.Prepare(ctx)
 	if status != http.StatusOK {
-		h.ctx.Status(status)
+		ctx.Status(status)
 		return
 	}
 	list, err := model.ClusterList(h.container.Db, &h.page)
@@ -154,7 +154,7 @@ func (h ClusterHandler) List(ctx *gin.Context) {
 		content = append(content, r)
 	}
 
-	h.ctx.JSON(http.StatusOK, content)
+	ctx.JSON(http.StatusOK, content)
 }
 
 //
@@ -162,7 +162,7 @@ func (h ClusterHandler) List(ctx *gin.Context) {
 func (h ClusterHandler) Get(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
-		h.ctx.Status(status)
+		ctx.Status(status)
 		return
 	}
 	content := Cluster{
@@ -171,7 +171,7 @@ func (h ClusterHandler) Get(ctx *gin.Context) {
 		Secret:    h.cluster.DecodeSecret(),
 	}
 
-	h.ctx.JSON(http.StatusOK, content)
+	ctx.JSON(http.StatusOK, content)
 }
 
 //

--- a/pkg/controller/discovery/web/ns.go
+++ b/pkg/controller/discovery/web/ns.go
@@ -30,13 +30,13 @@ func (h NsHandler) AddRoutes(r *gin.Engine) {
 func (h NsHandler) List(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
-		h.ctx.Status(status)
+		ctx.Status(status)
 		return
 	}
 	list, err := h.cluster.NsList(h.container.Db, &h.page)
 	if err != nil {
 		Log.Trace(err)
-		h.ctx.Status(http.StatusInternalServerError)
+		ctx.Status(http.StatusInternalServerError)
 		return
 	}
 	content := []Namespace{}
@@ -44,7 +44,7 @@ func (h NsHandler) List(ctx *gin.Context) {
 		content = append(content, m.Name)
 	}
 
-	h.ctx.JSON(http.StatusOK, content)
+	ctx.JSON(http.StatusOK, content)
 }
 
 //
@@ -52,11 +52,11 @@ func (h NsHandler) List(ctx *gin.Context) {
 func (h NsHandler) Get(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
-		h.ctx.Status(status)
+		ctx.Status(status)
 		return
 	}
 
-	h.ctx.JSON(http.StatusOK, h.cluster.Namespace)
+	ctx.JSON(http.StatusOK, h.cluster.Namespace)
 }
 
 // Namespace REST resource

--- a/pkg/controller/discovery/web/plan.go
+++ b/pkg/controller/discovery/web/plan.go
@@ -44,7 +44,7 @@ func (h *PlanHandler) Prepare(ctx *gin.Context) int {
 	}
 	h.plan = model.Plan{
 		Base: model.Base{
-			Namespace: h.ctx.Param("namespace"),
+			Namespace: h.ctx.Param("ns1"),
 			Name:      h.ctx.Param("plan"),
 		},
 	}

--- a/pkg/controller/discovery/web/plan.go
+++ b/pkg/controller/discovery/web/plan.go
@@ -44,8 +44,8 @@ func (h *PlanHandler) Prepare(ctx *gin.Context) int {
 	}
 	h.plan = model.Plan{
 		Base: model.Base{
-			Namespace: h.ctx.Param("ns1"),
-			Name:      h.ctx.Param("plan"),
+			Namespace: ctx.Param("ns1"),
+			Name:      ctx.Param("plan"),
 		},
 	}
 	err := h.plan.Select(h.container.Db)
@@ -86,13 +86,13 @@ func (h *PlanHandler) getSAR() auth.SelfSubjectAccessReview {
 func (h PlanHandler) List(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
-		h.ctx.Status(status)
+		ctx.Status(status)
 		return
 	}
 	list, err := model.PlanList(h.container.Db, &h.page)
 	if err != nil {
 		Log.Trace(err)
-		h.ctx.Status(http.StatusInternalServerError)
+		ctx.Status(http.StatusInternalServerError)
 		return
 	}
 	content := []Plan{}
@@ -106,7 +106,7 @@ func (h PlanHandler) List(ctx *gin.Context) {
 		content = append(content, d)
 	}
 
-	h.ctx.JSON(http.StatusOK, content)
+	ctx.JSON(http.StatusOK, content)
 }
 
 //
@@ -114,17 +114,17 @@ func (h PlanHandler) List(ctx *gin.Context) {
 func (h PlanHandler) Get(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
-		h.ctx.Status(status)
+		ctx.Status(status)
 		return
 	}
 	err := h.plan.Select(h.container.Db)
 	if err != nil {
 		if err != sql.ErrNoRows {
 			Log.Trace(err)
-			h.ctx.Status(http.StatusInternalServerError)
+			ctx.Status(http.StatusInternalServerError)
 			return
 		} else {
-			h.ctx.Status(http.StatusNotFound)
+			ctx.Status(http.StatusNotFound)
 			return
 		}
 	}
@@ -135,7 +135,7 @@ func (h PlanHandler) Get(ctx *gin.Context) {
 		Destination: h.plan.DecodeDestination(),
 	}
 
-	h.ctx.JSON(http.StatusOK, content)
+	ctx.JSON(http.StatusOK, content)
 }
 
 //
@@ -143,13 +143,13 @@ func (h PlanHandler) Get(ctx *gin.Context) {
 func (h PlanHandler) Pods(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
-		h.ctx.Status(status)
+		ctx.Status(status)
 		return
 	}
 	content := PlanPods{}
-	content.With(&h)
+	content.With(ctx, &h)
 
-	h.ctx.JSON(http.StatusOK, content)
+	ctx.JSON(http.StatusOK, content)
 }
 
 //
@@ -183,14 +183,14 @@ type PlanPods struct {
 //
 // Update the model `with` a PlanHandler
 // Fetch and build the pod lists.
-func (p *PlanPods) With(h *PlanHandler) error {
+func (p *PlanPods) With(ctx *gin.Context, h *PlanHandler) error {
 	var err error
 	p.Namespace = h.plan.Namespace
 	p.Name = h.plan.Name
 	p.Controller = []Pod{}
 	p.Source = []Pod{}
 	p.Destination = []Pod{}
-	p.Controller, err = p.buildController(h)
+	p.Controller, err = p.buildController(ctx, h)
 	if err != nil {
 		Log.Trace(err)
 		return err
@@ -212,7 +212,7 @@ func (p *PlanPods) With(h *PlanHandler) error {
 //
 // Build the controller pods list.
 // Finds pods by label.
-func (p *PlanPods) buildController(h *PlanHandler) ([]Pod, error) {
+func (p *PlanPods) buildController(ctx *gin.Context, h *PlanHandler) ([]Pod, error) {
 	pods := []Pod{}
 	list, err := model.PodListByLabel(
 		h.container.Db,
@@ -223,7 +223,7 @@ func (p *PlanPods) buildController(h *PlanHandler) ([]Pod, error) {
 		nil)
 	if err != nil {
 		Log.Trace(err)
-		h.ctx.Status(http.StatusInternalServerError)
+		ctx.Status(http.StatusInternalServerError)
 		return nil, err
 	}
 	if len(list) == 0 {

--- a/pkg/controller/discovery/web/pod.go
+++ b/pkg/controller/discovery/web/pod.go
@@ -312,7 +312,7 @@ func (p *Pod) With(pod *model.Pod, cluster *model.Cluster, filters ...ContainerF
 	p.Namespace = pod.Namespace
 	p.Name = pod.Name
 	path := LogRoot
-	path = strings.Replace(path, ":namespace", cluster.Namespace, 1)
+	path = strings.Replace(path, ":ns1", cluster.Namespace, 1)
 	path = strings.Replace(path, ":cluster", cluster.Name, 1)
 	path = strings.Replace(path, ":ns2", p.Namespace, 1)
 	path = strings.Replace(path, ":pod", p.Name, 1)

--- a/pkg/controller/discovery/web/pod.go
+++ b/pkg/controller/discovery/web/pod.go
@@ -43,7 +43,7 @@ func (h PodHandler) AddRoutes(r *gin.Engine) {
 func (h PodHandler) Get(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
-		h.ctx.Status(status)
+		ctx.Status(status)
 		return
 	}
 	namespace := ctx.Param("ns2")
@@ -59,16 +59,16 @@ func (h PodHandler) Get(ctx *gin.Context) {
 	if err != nil {
 		if err != sql.ErrNoRows {
 			Log.Trace(err)
-			h.ctx.Status(http.StatusInternalServerError)
+			ctx.Status(http.StatusInternalServerError)
 			return
 		} else {
-			h.ctx.Status(http.StatusNotFound)
+			ctx.Status(http.StatusNotFound)
 			return
 		}
 	}
 	d := Pod{}
 	d.With(&pod, &h.cluster)
-	h.ctx.JSON(http.StatusOK, d)
+	ctx.JSON(http.StatusOK, d)
 }
 
 //
@@ -76,7 +76,7 @@ func (h PodHandler) Get(ctx *gin.Context) {
 func (h PodHandler) List(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
-		h.ctx.Status(status)
+		ctx.Status(status)
 		return
 	}
 	ns := model.Namespace{
@@ -88,7 +88,7 @@ func (h PodHandler) List(ctx *gin.Context) {
 	list, err := ns.PodList(h.container.Db, &h.page)
 	if err != nil {
 		Log.Trace(err)
-		h.ctx.Status(http.StatusInternalServerError)
+		ctx.Status(http.StatusInternalServerError)
 		return
 	}
 	content := []Pod{}
@@ -98,7 +98,7 @@ func (h PodHandler) List(ctx *gin.Context) {
 		content = append(content, d)
 	}
 
-	h.ctx.JSON(http.StatusOK, content)
+	ctx.JSON(http.StatusOK, content)
 }
 
 //
@@ -124,7 +124,7 @@ func (h LogHandler) Get(ctx *gin.Context) {
 func (h LogHandler) List(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
-		h.ctx.Status(status)
+		ctx.Status(status)
 		return
 	}
 	namespace := ctx.Param("ns2")
@@ -140,28 +140,28 @@ func (h LogHandler) List(ctx *gin.Context) {
 	if err != nil {
 		if err != sql.ErrNoRows {
 			Log.Trace(err)
-			h.ctx.Status(http.StatusInternalServerError)
+			ctx.Status(http.StatusInternalServerError)
 			return
 		} else {
-			h.ctx.Status(http.StatusNotFound)
+			ctx.Status(http.StatusNotFound)
 			return
 		}
 	}
 
-	h.getLog(&pod)
+	h.getLog(ctx, &pod)
 }
 
 //
 // Get the k8s logs.
-func (h *LogHandler) getLog(pod *model.Pod) {
-	options, status := h.buildOptions()
+func (h *LogHandler) getLog(ctx *gin.Context, pod *model.Pod) {
+	options, status := h.buildOptions(ctx)
 	if status != http.StatusOK {
-		h.ctx.Status(status)
+		ctx.Status(status)
 		return
 	}
 	podClient, status := h.buildClient(pod)
 	if status != http.StatusOK {
-		h.ctx.Status(status)
+		ctx.Status(status)
 		return
 	}
 	request := podClient.GetLogs(pod.Name, options)
@@ -169,24 +169,24 @@ func (h *LogHandler) getLog(pod *model.Pod) {
 	if err != nil {
 		stErr, cast := err.(*errors.StatusError)
 		if cast {
-			h.ctx.String(int(stErr.ErrStatus.Code), stErr.ErrStatus.Message)
+			ctx.String(int(stErr.ErrStatus.Code), stErr.ErrStatus.Message)
 			return
 		}
 		Log.Trace(err)
-		h.ctx.Status(http.StatusInternalServerError)
+		ctx.Status(http.StatusInternalServerError)
 		return
 	}
-	h.writeBody(stream)
+	h.writeBody(ctx, stream)
 	stream.Close()
-	h.ctx.Status(http.StatusOK)
+	ctx.Status(http.StatusOK)
 }
 
 //
 // Write the json-encoded logs in the response.
-func (h *LogHandler) writeBody(stream io.ReadCloser) {
-	h.ctx.Header("Content-Type", "application/json; charset=utf-8")
+func (h *LogHandler) writeBody(ctx *gin.Context, stream io.ReadCloser) {
+	ctx.Header("Content-Type", "application/json; charset=utf-8")
 	// Begin `[`
-	_, err := h.ctx.Writer.Write([]byte("["))
+	_, err := ctx.Writer.Write([]byte("["))
 	if err != nil {
 		return
 	}
@@ -201,20 +201,20 @@ func (h *LogHandler) writeBody(stream io.ReadCloser) {
 			break
 		}
 		if ln > 0 {
-			_, err = h.ctx.Writer.Write([]byte(","))
+			_, err = ctx.Writer.Write([]byte(","))
 			if err != nil {
 				return
 			}
 		}
 		line, _ := json.Marshal(scanner.Text())
-		_, err = h.ctx.Writer.Write(line)
+		_, err = ctx.Writer.Write(line)
 		if err != nil {
 			return
 		}
 		ln++
 	}
 	// End `]`
-	_, err = h.ctx.Writer.Write([]byte("]"))
+	_, err = ctx.Writer.Write([]byte("]"))
 	if err != nil {
 		return
 	}
@@ -224,13 +224,13 @@ func (h *LogHandler) writeBody(stream io.ReadCloser) {
 // Build the k8s log API options based on parameters.
 // The `tail` parameter indicates that pagination is relative
 // to the last log entry.
-func (h *LogHandler) buildOptions() (*v1.PodLogOptions, int) {
+func (h *LogHandler) buildOptions(ctx *gin.Context) (*v1.PodLogOptions, int) {
 	options := v1.PodLogOptions{}
-	container := h.getContainer()
+	container := h.getContainer(ctx)
 	if container != "" {
 		options.Container = container
 	}
-	tail, status := h.getTail()
+	tail, status := h.getTail(ctx)
 	if status != http.StatusOK {
 		return nil, status
 	}
@@ -260,8 +260,8 @@ func (h *LogHandler) buildClient(pod *model.Pod) (capi.PodInterface, int) {
 
 //
 // Get the `tail` parameter.
-func (h *LogHandler) getTail() (bool, int) {
-	q := h.ctx.Request.URL.Query()
+func (h *LogHandler) getTail(ctx *gin.Context) (bool, int) {
+	q := ctx.Request.URL.Query()
 	s := q.Get("tail")
 	if s == "" {
 		return false, http.StatusOK
@@ -276,8 +276,8 @@ func (h *LogHandler) getTail() (bool, int) {
 
 //
 // Get the `container` parameter.
-func (h *LogHandler) getContainer() string {
-	q := h.ctx.Request.URL.Query()
+func (h *LogHandler) getContainer(ctx *gin.Context) string {
+	q := ctx.Request.URL.Query()
 	return q.Get("container")
 }
 

--- a/pkg/controller/discovery/web/pv.go
+++ b/pkg/controller/discovery/web/pv.go
@@ -34,13 +34,13 @@ func (h PvHandler) AddRoutes(r *gin.Engine) {
 func (h PvHandler) List(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
-		h.ctx.Status(status)
+		ctx.Status(status)
 		return
 	}
 	list, err := h.cluster.PvList(h.container.Db, &h.page)
 	if err != nil {
 		Log.Trace(err)
-		h.ctx.Status(http.StatusInternalServerError)
+		ctx.Status(http.StatusInternalServerError)
 		return
 	}
 	content := []v1.PersistentVolume{}
@@ -50,7 +50,7 @@ func (h PvHandler) List(ctx *gin.Context) {
 		content = append(content, r)
 	}
 
-	h.ctx.JSON(http.StatusOK, content)
+	ctx.JSON(http.StatusOK, content)
 }
 
 //
@@ -58,29 +58,29 @@ func (h PvHandler) List(ctx *gin.Context) {
 func (h PvHandler) Get(ctx *gin.Context) {
 	status := h.Prepare(ctx)
 	if status != http.StatusOK {
-		h.ctx.Status(status)
+		ctx.Status(status)
 		return
 	}
 	pv := model.PV{
 		Base: model.Base{
 			Cluster: h.cluster.PK,
-			Name:    h.ctx.Param("pv"),
+			Name:    ctx.Param("pv"),
 		},
 	}
 	err := pv.Select(h.container.Db)
 	if err != nil {
 		if err != sql.ErrNoRows {
 			Log.Trace(err)
-			h.ctx.Status(http.StatusInternalServerError)
+			ctx.Status(http.StatusInternalServerError)
 			return
 		} else {
-			h.ctx.Status(http.StatusNotFound)
+			ctx.Status(http.StatusNotFound)
 			return
 		}
 	}
 	r := PV{}
 	json.Unmarshal([]byte(pv.Definition), &r)
-	h.ctx.JSON(http.StatusOK, r)
+	ctx.JSON(http.StatusOK, r)
 }
 
 // PV REST resource

--- a/pkg/controller/discovery/web/web.go
+++ b/pkg/controller/discovery/web/web.go
@@ -28,7 +28,7 @@ var Log *logging.Logger
 
 // Root - all routes.
 const (
-	Root = "/namespaces/:namespace"
+	Root = "/namespaces/:ns1"
 )
 
 //


### PR DESCRIPTION
Clean up some minor tech debt.
1. Use inline function w/ defer mutex.RUnlock().  Better practice.
2. renamed `:namespace` variable in URL patterns to `:ns1` for clarity and consistency with `:ns2`.
3. The `BaseHandler` had a `ctx` (request context) field but was also being passed. The passed `ctx` makes more sense.  Removed the field.