### PR TITLE
The Status.ObservedGeneration should to be optional.

### DIFF
--- a/config/crds/migration_v1alpha1_migcluster.yaml
+++ b/config/crds/migration_v1alpha1_migcluster.yaml
@@ -64,8 +64,6 @@ spec:
             observedGeneration:
               format: int64
               type: integer
-          required:
-          - observedGeneration
           type: object
   version: v1alpha1
 status:

--- a/config/crds/migration_v1alpha1_migmigration.yaml
+++ b/config/crds/migration_v1alpha1_migmigration.yaml
@@ -55,8 +55,6 @@ spec:
             startTimestamp:
               format: date-time
               type: string
-          required:
-          - observedGeneration
           type: object
   version: v1alpha1
 status:

--- a/config/crds/migration_v1alpha1_migplan.yaml
+++ b/config/crds/migration_v1alpha1_migplan.yaml
@@ -96,8 +96,6 @@ spec:
             observedGeneration:
               format: int64
               type: integer
-          required:
-          - observedGeneration
           type: object
   version: v1alpha1
 status:

--- a/config/crds/migration_v1alpha1_migstorage.yaml
+++ b/config/crds/migration_v1alpha1_migstorage.yaml
@@ -88,8 +88,6 @@ spec:
             observedGeneration:
               format: int64
               type: integer
-          required:
-          - observedGeneration
           type: object
   version: v1alpha1
 status:

--- a/pkg/apis/migration/v1alpha1/migcluster_types.go
+++ b/pkg/apis/migration/v1alpha1/migcluster_types.go
@@ -54,7 +54,7 @@ type MigClusterSpec struct {
 // MigClusterStatus defines the observed state of MigCluster
 type MigClusterStatus struct {
 	Conditions
-	ObservedGeneration int64 `json:"observedGeneration"`
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/migration/v1alpha1/migmigration_types.go
+++ b/pkg/apis/migration/v1alpha1/migmigration_types.go
@@ -40,7 +40,7 @@ type MigMigrationSpec struct {
 type MigMigrationStatus struct {
 	Conditions
 	UnhealthyResources
-	ObservedGeneration int64        `json:"observedGeneration"`
+	ObservedGeneration int64        `json:"observedGeneration,omitempty"`
 	StartTimestamp     *metav1.Time `json:"startTimestamp,omitempty"`
 	Phase              string       `json:"phase,omitempty"`
 	Errors             []string     `json:"errors,omitempty"`

--- a/pkg/apis/migration/v1alpha1/migplan_types.go
+++ b/pkg/apis/migration/v1alpha1/migplan_types.go
@@ -57,7 +57,7 @@ type MigPlanSpec struct {
 // MigPlanStatus defines the observed state of MigPlan
 type MigPlanStatus struct {
 	Conditions
-	ObservedGeneration int64 `json:"observedGeneration"`
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/migration/v1alpha1/migstorage_types.go
+++ b/pkg/apis/migration/v1alpha1/migstorage_types.go
@@ -44,7 +44,7 @@ type MigStorageSpec struct {
 // MigStorageStatus defines the observed state of MigStorage
 type MigStorageStatus struct {
 	Conditions
-	ObservedGeneration int64 `json:"observedGeneration"`
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient


### PR DESCRIPTION
Probably should be optional so that existing CRs will be valid.  The default would still be 0.